### PR TITLE
Revert removing EZID and use longer google cloud name

### DIFF
--- a/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
+++ b/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
@@ -446,6 +446,16 @@
 						"OptionName": "org.sagebionetworks.s3.bucket",
 						"Value": "${stack}data.sagebase.org"
 					},
+					{
+						"Namespace": "aws:elasticbeanstalk:application:environment",
+						"OptionName": "org.sagebionetworks.ezid.username",
+						"Value": "sagebio"
+					},
+					{
+						"Namespace": "aws:elasticbeanstalk:application:environment",
+						"OptionName": "org.sagebionetworks.ezid.doi.prefix",
+						"Value": "doi:10.7303/"
+					},
                     {
                         "Namespace": "aws:elasticbeanstalk:application:environment",
                         "OptionName": "org.sagebionetworks.doi.prefix",

--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -37,6 +37,7 @@ org.sagebionetworks.beanstalk.ssl.arn.portal=arn:aws:acm:us-east-1:449435941126:
 org.sagebionetworks.secret.keys.csv=org.sagebionetworks.id.generator.database.password\
 , org.sagebionetworks.repository.database.password\
 , org.sagebionetworks.migration.admin.apikey\
+, org.sagebionetworks.ezid.password\
 , org.sagebionetworks.repo.manager.jira.user.password\
 , org.sagebionetworks.oauth2.orcid.client.id\
 , org.sagebionetworks.oauth2.orcid.client.secret\
@@ -51,8 +52,7 @@ org.sagebionetworks.secret.keys.csv=org.sagebionetworks.id.generator.database.pa
 , org.sagebionetworks.hmac.signing.key.version.0\
 , org.sagebionetworks.hmac.signing.key.version.1\
 , org.sagebionetworks.doi.datacite.username\
-, org.sagebionetworks.doi.datacite.password\
-, org.sagebionetworks.gcp.key
+, org.sagebionetworks.doi.datacite.password
 
 # The Elastic Beanstalk Encrypted Image Versions
 # See https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.java

--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -52,7 +52,8 @@ org.sagebionetworks.secret.keys.csv=org.sagebionetworks.id.generator.database.pa
 , org.sagebionetworks.hmac.signing.key.version.0\
 , org.sagebionetworks.hmac.signing.key.version.1\
 , org.sagebionetworks.doi.datacite.username\
-, org.sagebionetworks.doi.datacite.password
+, org.sagebionetworks.doi.datacite.password\
+, org.sagebionetworks.google.cloud.key
 
 # The Elastic Beanstalk Encrypted Image Versions
 # See https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.java


### PR DESCRIPTION
not convinced that the prod build won't break when we remove EZID and i decided i like the google.cloud name more than gcp