### PR TITLE
Added stream for testing

### DIFF
--- a/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/KinesisFirehoseStreamDescriptor.java
+++ b/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/KinesisFirehoseStreamDescriptor.java
@@ -10,7 +10,12 @@ public class KinesisFirehoseStreamDescriptor {
 	public static final int MAX_BUFFER_SIZE = 128;
 
 	private String name;
-	// Partitioning prefix for the stream in S3 (See https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html)
+	// True if the stream data destination should be parameterized by the stack instance
+	private boolean parameterizeDestinationByStack = false;
+	// True if the stream should be deployed only in the dev stack
+	private boolean devOnly = false;
+	// Partitioning prefix for the stream in S3 (See
+	// https://docs.aws.amazon.com/firehose/latest/dev/s3-prefixes.html)
 	private String partitionScheme = "!{timestamp:yyyy-MM-dd}";
 	// Buffer flush interval in seconds
 	private int bufferFlushInterval = MAX_BUFFER_INTERVAL;
@@ -27,6 +32,22 @@ public class KinesisFirehoseStreamDescriptor {
 
 	public void setName(String name) {
 		this.name = name;
+	}
+
+	public boolean isParameterizeDestinationByStack() {
+		return parameterizeDestinationByStack;
+	}
+	
+	public void setParameterizeDestinationByStack(boolean parameterizeDestinationByStack) {
+		this.parameterizeDestinationByStack = parameterizeDestinationByStack;
+	}
+
+	public boolean isDevOnly() {
+		return devOnly;
+	}
+
+	public void setDevOnly(boolean devOnly) {
+		this.devOnly = devOnly;
 	}
 
 	public String getPartitionScheme() {
@@ -71,22 +92,25 @@ public class KinesisFirehoseStreamDescriptor {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(bufferFlushInterval, bufferFlushSize, format, name, partitionScheme, tableDescriptor);
+		return Objects.hash(bufferFlushInterval, bufferFlushSize, devOnly, format, name, parameterizeDestinationByStack, partitionScheme,
+				tableDescriptor);
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		KinesisFirehoseStreamDescriptor other = (KinesisFirehoseStreamDescriptor) obj;
-		return bufferFlushInterval == other.bufferFlushInterval && bufferFlushSize == other.bufferFlushSize
-				&& format == other.format && Objects.equals(name, other.name)
-				&& Objects.equals(partitionScheme, other.partitionScheme)
-				&& Objects.equals(tableDescriptor, other.tableDescriptor);
+		return bufferFlushInterval == other.bufferFlushInterval && bufferFlushSize == other.bufferFlushSize && devOnly == other.devOnly
+				&& format == other.format && Objects.equals(name, other.name) && parameterizeDestinationByStack == other.parameterizeDestinationByStack
+				&& Objects.equals(partitionScheme, other.partitionScheme) && Objects.equals(tableDescriptor, other.tableDescriptor);
 	}
 
 }

--- a/src/main/resources/templates/repo/kinesis-log-streams.json
+++ b/src/main/resources/templates/repo/kinesis-log-streams.json
@@ -55,5 +55,32 @@
 				"day": "string"
 			}
 		}
+	},
+	{
+		"name": "fileDownloadsTest",
+		"devOnly": true,
+		"parameterizeDestinationByStack": true,
+		"partitionScheme": "year=!{timestamp:YYYY}/month=!{timestamp:MM}/day=!{timestamp:dd}",
+		"format": "PARQUET",
+		"bufferFlushSize": 64,
+		"bufferFlushInterval": 60,
+		"tableDescriptor": {
+			"name": "fileDownloadsRecordsTest",
+			"columns": {
+				"userId": "bigint",
+				"timestamp": "timestamp",
+				"projectId": "bigint",
+				"fileHandleId": "string",
+				"associateType": "string",
+				"associateId": "string",
+				"stack": "string",
+				"instance": "string"
+			},
+			"partitionKeys": {
+				"year": "string",
+				"month": "string",
+				"day": "string"
+			}
+		}
 	}]
 }

--- a/src/main/resources/templates/repo/kinesis-log-streams.json.vpt
+++ b/src/main/resources/templates/repo/kinesis-log-streams.json.vpt
@@ -43,7 +43,15 @@
 									"arn:aws:s3:::${stack}.log.sagebase.org",
 									"arn:aws:s3:::${stack}.log.sagebase.org/*"
 								]
-							},
+							}
+						]
+					}
+				},
+				{
+					"PolicyName":"kinesisReadGlueTablesPolicy",
+					"PolicyDocument":{
+						"Version":"2012-10-17",
+						"Statement":[
 							{
 								"Effect":"Allow",
 								"Action": [
@@ -115,7 +123,11 @@
 					$exceptionThrower.throwException("Unsupported format: ${stream.format}")
 					#end,
 					"Compressed": false,
+					#if ($stream.parameterizeDestinationByStack)
+					"Location": "s3://${stack}.log.sagebase.org/${stack}${instance}${stream.name}/records"
+					#else
 					"Location": "s3://${stack}.log.sagebase.org/${stream.name}/records"
+					#end
 				},
 				"PartitionKeys": [
 					#foreach($partitionKey in $stream.tableDescriptor.partitionKeys.entrySet())
@@ -146,8 +158,13 @@
 					]
 				},
 				"BucketARN":"arn:aws:s3:::${stack}.log.sagebase.org",
+				#if ($stream.parameterizeDestinationByStack)
+				"Prefix":"${stack}${instance}${stream.name}/records/${stream.partitionScheme}/",
+				"ErrorOutputPrefix":"${stack}${instance}${stream.name}/errors/!{firehose:error-output-type}/!{timestamp:yyyy-MM-dd}/",
+				#else
 				"Prefix":"${stream.name}/records/${stream.partitionScheme}/",
 				"ErrorOutputPrefix":"${stream.name}/errors/!{firehose:error-output-type}/!{timestamp:yyyy-MM-dd}/",
+				#end
 				"BufferingHints":{
 					"IntervalInSeconds":${stream.bufferFlushInterval},
 					"SizeInMBs":${stream.bufferFlushSize}
@@ -198,8 +215,13 @@
 					},
 					"BucketARN":"arn:aws:s3:::${stack}.log.sagebase.org",
 					"CompressionFormat" : "GZIP",
+					#if ($stream.parameterizeDestinationByStack)
+					"Prefix":"${stack}${instance}${stream.name}/backup/records/${stream.partitionScheme}/",
+					"ErrorOutputPrefix":"${stack}${instance}${stream.name}/backup/errors/!{firehose:error-output-type}/!{timestamp:yyyy-MM-dd}/",
+					#else
 					"Prefix":"${stream.name}/backup/records/${stream.partitionScheme}/",
 					"ErrorOutputPrefix":"${stream.name}/backup/errors/!{firehose:error-output-type}/!{timestamp:yyyy-MM-dd}/",
+					#end
 					"BufferingHints":{
 						"IntervalInSeconds":${stream.bufferFlushInterval},
 						"SizeInMBs":${stream.bufferFlushSize}

--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -62,9 +62,5 @@ org.sagebionetworks.beanstalk.image.version.java=8
 org.sagebionetworks.beanstalk.image.version.tomcat=8.5
 #use "latest" for latest supported version of Amazon Linux or a specific version such as "3.0.6"
 org.sagebionetworks.beanstalk.image.version.amazonlinux=3.0.7
-
-#comma separated list of kinesis firehose stream names 
-org.sagebionetworks.kinesis.firehose.log.stream.names=cloudsearchDocumentGeneration
-
 # The Synapse OAuth authorization endpoint
 org.sagebionetworks.oauth.authorization.endpoint=https://signin.synapse.org

--- a/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseVelocityContextProviderTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseVelocityContextProviderTest.java
@@ -54,6 +54,7 @@ public class KinesisFirehoseVelocityContextProviderTest {
 	public void before() {
 		MockitoAnnotations.initMocks(this);
 		testStreams = Collections.singleton(mockStream);
+		when(mockStream.isDevOnly()).thenReturn(false);
 		when(mockRepoConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(testStack);
 		when(mockRepoConfig.getProperty(PROPERTY_KEY_INSTANCE)).thenReturn(testInstance);
 		when(mockStream.getTableDescriptor()).thenReturn(mockTable);
@@ -67,6 +68,27 @@ public class KinesisFirehoseVelocityContextProviderTest {
 		
 		verify(mockContext).put(GLUE_DATABASE_NAME, (testStack + testInstance + GLUE_DB_SUFFIX));
 		verify(mockContext).put(KINESIS_FIREHOSE_STREAM_DESCRIPTORS, testStreams);
+	}
+	
+	@Test
+	public void testAddToContextWithoutDevOnlyStreams() {
+		when(mockStream.isDevOnly()).thenReturn(true);
+		
+		contextProvider.addToContext(mockContext);
+		
+		verify(mockContext).put(KINESIS_FIREHOSE_STREAM_DESCRIPTORS, Collections.emptySet());
+	}
+	
+	@Test
+	public void testAddToContextWithDevOnlyStreams() {
+		String devStack = "dev";
+		
+		when(mockRepoConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(devStack);
+		when(mockStream.isDevOnly()).thenReturn(true);
+		
+		contextProvider.addToContext(mockContext);
+		
+		verify(mockContext).put(KINESIS_FIREHOSE_STREAM_DESCRIPTORS, Collections.singleton(mockStream));
 	}
 	
 	@Test


### PR DESCRIPTION
I added a new stream whose sole purpose is for testing, in this way I do not have to fiddle in the repo services with creating streams at test time, also allows us to reuse the same machinery. Added a new property to the stream so that we can configure the stream to be created only on dev (e.g. we do not need this in prod). Also the stream has a new property parameterizeDestinationByStack that allows to define the destination in S3 parameterized by the current stack, so that each build is isolated.