### PR TITLE
Avoid adding devOnly streams to prod only

### DIFF
--- a/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/KinesisFirehoseVelocityContextProvider.java
+++ b/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/KinesisFirehoseVelocityContextProvider.java
@@ -16,7 +16,7 @@ import com.google.inject.Inject;
 
 public class KinesisFirehoseVelocityContextProvider implements VelocityContextProvider {
 
-	private static final String DEV_STACK_NAME = "dev";
+	private static final String PROD_STACK_NAME = "prod";
 	public static final String GLUE_DB_SUFFIX = "firehoseLogs";
 
 	private KinesisFirehoseConfig config;
@@ -35,7 +35,7 @@ public class KinesisFirehoseVelocityContextProvider implements VelocityContextPr
 		Set<KinesisFirehoseStreamDescriptor> streams = config.getStreamDescriptors();
 
 		// Does not deploy to prod stacks that are dev only
-		if (!getStack().equalsIgnoreCase(DEV_STACK_NAME)) {
+		if (getStack().equalsIgnoreCase(PROD_STACK_NAME)) {
 			streams = streams.stream().filter(stream -> !stream.isDevOnly()).collect(Collectors.toSet());
 		}
 


### PR DESCRIPTION
I went back to actually avoid deploying the devOnly stream only when the stack is prod (instead of checking if the stack is dev). This would allow to create another stack with a different name but still have the integration tests passing.