### PR TITLE
Use specific AWS SDK dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,41 @@
 			<artifactId>commons-codec</artifactId>
 			<version>1.11</version>
 		</dependency>
-		<!-- The AWS Java SDK -->
+		<!-- The AWS Java SDK Dependencies -->
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-			<version>1.11.338</version>
+			<artifactId>aws-java-sdk-cloudformation</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-secretsmanager</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-elasticloadbalancingv2</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-kms</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-ec2</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-elasticbeanstalk</artifactId>
+			<version>${amazon.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.inject</groupId>
@@ -125,7 +155,7 @@
 			<!-- Bundles all dependencies with the jar -->
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.1.1</version>
 				<configuration>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
@@ -154,5 +184,6 @@
 	</build>
 	<properties>
 		<bouncycastle.version>1.60</bouncycastle.version>
+		<amazon.sdk.version>1.11.338</amazon.sdk.version>
 	</properties>
 </project>


### PR DESCRIPTION
This gets us from a couple of minutes for the build to a few seconds for building the jar