### PR TITLE
PLFM-5936: Ignores missing SES alarm data points

### DIFF
--- a/src/main/resources/templates/vpc/main-vpc.json.vtp
+++ b/src/main/resources/templates/vpc/main-vpc.json.vtp
@@ -202,7 +202,7 @@
 				"Namespace" : "AWS/SES",
 				"Statistic" : "Maximum",
 				"Threshold" : 0.05,
-				"TreatMissingData" : "notBreaching"
+				"TreatMissingData" : "ignore"
 			}
 		}
 		#end	


### PR DESCRIPTION
See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data