### PR TITLE
add STS temp credentials IAM role

### DIFF
--- a/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
+++ b/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
@@ -480,6 +480,11 @@
 						"Namespace": "aws:elasticbeanstalk:application:environment",
 						"OptionName": "org.sagebionetworks.oauth.authorization.endpoint",
 						"Value": "${oauthEndpoint}"
+					},
+					{
+						"Namespace": "aws:elasticbeanstalk:application:environment",
+						"OptionName": "org.sagebionetworks.sts.iam.arn",
+						"Value": {"Fn::ImportValue": "${sharedExportPrefix}-Temp-Credentials-Service-Role-Arn"}
 					}
 
 					#end

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -511,6 +511,7 @@
 						}
 					]
 				},
+				"MaxSessionDuration":43200,
 				"Path": "/",
 				"Policies": [
 					{

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -423,7 +423,7 @@
                                 {
                                     "Effect": "Allow",
                                     "Action": [
-                                        "sts:*"
+                                        "sts:AssumeRole"
                                     ],
                                     "Resource": "*"
                                 }
@@ -503,7 +503,13 @@
 						{
 							"Effect": "Allow",
 							"Principal": {
-								"AWS": {"Ref": "AWS::AccountId"}
+								"AWS": {
+									#if(${stack} == 'dev')
+										"Ref": "AWS::AccountId"
+									#else
+										"Fn::GetAtt" : ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]
+									#end
+								}
 							},
 							"Action": [
 								"sts:AssumeRole"
@@ -671,6 +677,28 @@
 								"Ref": "AWS::StackName"
 							},
 							"Load-Balancer-Security-Group-ID"
+						]
+					]
+				}
+			}
+		},
+		"TempCredentialsServiceRoleArn":{
+			"Description": "The ARN for the IAM Role that the StsManager uses. We call AssumeRole on this ARN to generate the temporary S3 credentials that we pass to the caller.",
+			"Value": {
+				"Fn::GetAtt" : ["${stack}${instance}SynapseTempCredentialsServiceRole", "Arn"]
+			},
+			"Export": {
+				"Name": {
+					"Fn::Join": [
+						"-",
+						[
+							{
+								"Ref": "AWS::Region"
+							},
+							{
+								"Ref": "AWS::StackName"
+							},
+							"Temp-Credentials-Service-Role-Arn"
 						]
 					]
 				}

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -503,9 +503,7 @@
 						{
 							"Effect": "Allow",
 							"Principal": {
-								"Service": [
-									"ec2.amazonaws.com"
-								]
+								"AWS": {"Ref": "AWS::AccountId"}
 							},
 							"Action": [
 								"sts:AssumeRole"

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -494,6 +494,51 @@
 				]
 			}
 		},
+		"${stack}${instance}SynapseTempCredentialsServiceRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {
+								"Service": [
+									"ec2.amazonaws.com"
+								]
+							},
+							"Action": [
+								"sts:AssumeRole"
+							]
+						}
+					]
+				},
+				"Path": "/",
+				"Policies": [
+					{
+						"PolicyName" : "${stack}${instance}SynapseTempCredentialsService",
+						"PolicyDocument": {
+							"Version": "2012-10-17",
+							"Statement": [
+								{
+									"Action": [
+										"s3:AbortMultipartUpload",
+										"s3:DeleteObject",
+										"s3:GetObject",
+										"s3:ListBucket",
+										"s3:ListMultipartUploadParts",
+										"s3:PutObject",
+										"s3:ListBucketMultipartUploads"
+									],
+									"Effect": "Allow",
+									"Resource": "*"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
 		"${stack}${instance}CMK": {
 			"Type": "AWS::KMS::Key",
 			"DependsOn":["${stack}${instance}SynapesRepoWorkersServiceRole"],


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/PLFM-6008

GetFederationToken cannot be called by an IAM Role, and Elastic Beanstalk uses IAM roles by default. We switched from GetFederationToken to AssumeRole, which requires an IAM Role specific for this purpose.

This new role can be assumed by anyone in our AWS Account. This is to enable any machine account and any Synapse developer to use this role.

The new role has permissions on any S3 bucket, because it will be used for vending STS credentials for STS-enabled storage locations. However, we're only granting it the specific set of permissions that the Synapse STS Manager vends.