### PR TITLE
PLFM-6426: Support S3 inventory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
 			<version>${amazon.sdk.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
+			<version>${amazon.sdk.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
 			<version>4.2.0</version>
@@ -129,21 +134,58 @@
 		</dependency>
 		<!-- Testing -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<groupId>org.sagebionetworks</groupId>
+			<artifactId>lib-utils</artifactId>
+			<version>316.0</version>
+		</dependency>
+		<!--interface between junit5 and programmatic clients, such as IDEs and 
+				build tools, for running tests -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>${junit.platform.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!--adds a subset of junit5 functionality to tests currently running under 
+			junit4. should be REMOVED once fully converted to junit5 -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-runner</artifactId>
+			<version>${junit.platform.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!--junit5 engine -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!--junit4 engine for backwards compatibility -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
+			<version>${junit.vintage.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito.version}</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.sagebionetworks</groupId>
-			<artifactId>lib-utils</artifactId>
-			<version>316.0</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -191,5 +233,9 @@
 		<bouncycastle.version>1.60</bouncycastle.version>
 		<amazon.sdk.version>1.11.338</amazon.sdk.version>
 		<log4j.version>2.13.3</log4j.version>
+		<junit.jupiter.version>5.4.1</junit.jupiter.version>
+		<junit.vintage.version>5.4.1</junit.vintage.version>
+		<junit.platform.version>1.4.1</junit.platform.version>
+		<mockito.version>2.27.0</mockito.version>
 	</properties>
 </project>

--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
 	public static final String SNS_AND_SQS_CONFIG_FILE = "templates/repo/sns-and-sqs-config.json";
 	public static final String KINESIS_CONFIG_FILE = "templates/repo/kinesis-log-streams.json";
 	public static final String CLOUDWATCH_LOGS_CONFIG_FILE = "templates/repo/cloudwatch-logs-config.json";
+	public static final String S3_CONFIG_FILE = "templates/s3/s3-buckets-config.json";
 
 	/**
 	 * A VPC peering role ARN must start with this prefix.
@@ -72,7 +73,6 @@ public class Constants {
 	public static final String PROPERTY_KEY_SECRET_KEYS_CSV = "org.sagebionetworks.secret.keys.csv";
 	public static final String PROPERTY_KEY_REPOSITORY_DATABASE_PASSWORD = "org.sagebionetworks.repository.database.password";
 	public static final String PROPERTY_KEY_ID_GENERATOR_DATABASE_PASSWORD = "org.sagebionetworks.id.generator.database.password";
-	public static final String PROPERTY_KEY_S3_BUCKETS_CSV = "org.sagebionetworks.s3.buckets";
 	
 	public static final String PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_PREFIX = "org.sagebionetworks.beanstalk.image.version.";
 	public static final String PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_JAVA = PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_PREFIX + "java";
@@ -95,6 +95,7 @@ public class Constants {
 	public static final String TEMPALTE_SHARED_RESOUCES_MAIN_JSON_VTP = "templates/repo/main-repo-shared-resources-template.json.vpt";
 	public static final String TEMPALTE_BEAN_STALK_ENVIRONMENT = "templates/repo/elasticbeanstalk-template.json.vpt";
 	public static final String TEMPLATE_ID_GENERATOR = "templates/repo/id-generator-template.json.vpt";
+	public static final String TEMPLATE_INVENTORY_BUCKET_POLICY_TEMPLATE = "templates/s3/s3-inventory-bucket-policy.json.vpt";
 	
 
 	public static final int JSON_INDENT = 5;

--- a/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
+++ b/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
@@ -20,8 +20,6 @@ import org.sagebionetworks.template.repo.IdGeneratorBuilder;
 import org.sagebionetworks.template.repo.IdGeneratorBuilderImpl;
 import org.sagebionetworks.template.repo.RepositoryTemplateBuilder;
 import org.sagebionetworks.template.repo.RepositoryTemplateBuilderImpl;
-import org.sagebionetworks.template.repo.S3BucketBuilder;
-import org.sagebionetworks.template.repo.S3BucketBuilderImpl;
 import org.sagebionetworks.template.repo.VelocityContextProvider;
 import org.sagebionetworks.template.repo.WebACLBuilder;
 import org.sagebionetworks.template.repo.WebACLBuilderImpl;
@@ -46,6 +44,8 @@ import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseConfigV
 import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseVelocityContextProvider;
 import org.sagebionetworks.template.repo.queues.SnsAndSqsConfig;
 import org.sagebionetworks.template.repo.queues.SnsAndSqsVelocityContextProvider;
+import org.sagebionetworks.template.s3.S3BucketBuilder;
+import org.sagebionetworks.template.s3.S3BucketBuilderImpl;
 import org.sagebionetworks.template.vpc.VpcTemplateBuilder;
 import org.sagebionetworks.template.vpc.VpcTemplateBuilderImpl;
 import org.sagebionetworks.war.WarAppender;

--- a/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
+++ b/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
@@ -46,6 +46,8 @@ import org.sagebionetworks.template.repo.queues.SnsAndSqsConfig;
 import org.sagebionetworks.template.repo.queues.SnsAndSqsVelocityContextProvider;
 import org.sagebionetworks.template.s3.S3BucketBuilder;
 import org.sagebionetworks.template.s3.S3BucketBuilderImpl;
+import org.sagebionetworks.template.s3.S3Config;
+import org.sagebionetworks.template.s3.S3ConfigValidator;
 import org.sagebionetworks.template.vpc.VpcTemplateBuilder;
 import org.sagebionetworks.template.vpc.VpcTemplateBuilderImpl;
 import org.sagebionetworks.war.WarAppender;
@@ -63,6 +65,9 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.Multibinder;
@@ -70,6 +75,7 @@ import com.google.inject.multibindings.Multibinder;
 import static org.sagebionetworks.template.Constants.CLOUDWATCH_LOGS_CONFIG_FILE;
 import static org.sagebionetworks.template.Constants.KINESIS_CONFIG_FILE;
 import static org.sagebionetworks.template.Constants.SNS_AND_SQS_CONFIG_FILE;
+import static org.sagebionetworks.template.Constants.S3_CONFIG_FILE;
 
 public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 
@@ -103,6 +109,7 @@ public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 		bind(CloudwatchLogsVelocityContextProvider.class).to(CloudwatchLogsVelocityContextProviderImpl.class);
 
 		Multibinder<VelocityContextProvider> velocityContextProviderMultibinder = Multibinder.newSetBinder(binder(), VelocityContextProvider.class);
+		
 		velocityContextProviderMultibinder.addBinding().to(SnsAndSqsVelocityContextProvider.class);
 		velocityContextProviderMultibinder.addBinding().to(KinesisFirehoseVelocityContextProvider.class);
 	}
@@ -175,6 +182,14 @@ public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 	}
 	
 	@Provides
+	public AWSSecurityTokenService provideAmazonSts() {
+		AWSSecurityTokenServiceClientBuilder builder = AWSSecurityTokenServiceClientBuilder.standard();
+		builder.withCredentials(new DefaultAWSCredentialsProviderChain());
+		builder.withRegion(Regions.US_EAST_1);
+		return builder.build();
+	}
+	
+	@Provides
 	public VelocityEngine velocityEngineProvider() {
 		VelocityEngine engine = new VelocityEngine();
 		engine.setProperty(RuntimeConstants.RESOURCE_LOADER, CLASSPATH_AND_FILE); 
@@ -197,6 +212,11 @@ public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 	@Provides
 	public CloudwatchLogsConfig cloudwatchLogsConfigProvider() throws IOException {
 		return new CloudwatchLogsConfigValidator(loadFromJsonFile(CLOUDWATCH_LOGS_CONFIG_FILE, CloudwatchLogsConfig.class)).validate();
+	}
+	
+	@Provides
+	public S3Config s3ConfigProvider() throws IOException {
+		return new S3ConfigValidator(loadFromJsonFile(S3_CONFIG_FILE, S3Config.class)).validate();
 	}
 	
 	private static <T> T loadFromJsonFile(String file, Class<T> clazz) throws IOException {

--- a/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilder.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilder.java
@@ -1,4 +1,4 @@
-package org.sagebionetworks.template.repo;
+package org.sagebionetworks.template.s3;
 
 public interface S3BucketBuilder {
 

--- a/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilderImpl.java
@@ -1,9 +1,8 @@
-package org.sagebionetworks.template.repo;
+package org.sagebionetworks.template.s3;
 
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_S3_BUCKETS_CSV;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 
-import org.sagebionetworks.template.TemplateGuiceModule;
 import org.sagebionetworks.template.config.RepoConfiguration;
 
 import com.amazonaws.AmazonServiceException;
@@ -13,9 +12,7 @@ import com.amazonaws.services.s3.model.ServerSideEncryptionByDefault;
 import com.amazonaws.services.s3.model.ServerSideEncryptionConfiguration;
 import com.amazonaws.services.s3.model.ServerSideEncryptionRule;
 import com.amazonaws.services.s3.model.SetBucketEncryptionRequest;
-import com.google.inject.Guice;
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 
 public class S3BucketBuilderImpl implements S3BucketBuilder {
 
@@ -56,12 +53,6 @@ public class S3BucketBuilderImpl implements S3BucketBuilder {
 				}
 			} 
 		}
-	}
-	
-	public static void main(String[] args) throws InterruptedException {
-		Injector injector = Guice.createInjector(new TemplateGuiceModule());
-		S3BucketBuilder builder = injector.getInstance(S3BucketBuilder.class);
-		builder.buildAllBuckets();
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3BucketBuilderImpl.java
@@ -1,58 +1,244 @@
 package org.sagebionetworks.template.s3;
 
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_S3_BUCKETS_CSV;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
+import static org.sagebionetworks.template.Constants.TEMPLATE_INVENTORY_BUCKET_POLICY_TEMPLATE;
 
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
 import org.sagebionetworks.template.config.RepoConfiguration;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
 import com.amazonaws.services.s3.model.ServerSideEncryptionByDefault;
 import com.amazonaws.services.s3.model.ServerSideEncryptionConfiguration;
 import com.amazonaws.services.s3.model.ServerSideEncryptionRule;
 import com.amazonaws.services.s3.model.SetBucketEncryptionRequest;
+import com.amazonaws.services.s3.model.inventory.InventoryConfiguration;
+import com.amazonaws.services.s3.model.inventory.InventoryDestination;
+import com.amazonaws.services.s3.model.inventory.InventoryFrequency;
+import com.amazonaws.services.s3.model.inventory.InventoryIncludedObjectVersions;
+import com.amazonaws.services.s3.model.inventory.InventoryS3BucketDestination;
+import com.amazonaws.services.s3.model.inventory.InventorySchedule;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
 import com.google.inject.Inject;
 
 public class S3BucketBuilderImpl implements S3BucketBuilder {
 
-	AmazonS3 s3Client;
-	RepoConfiguration config;
+	private static final Logger logger = LogManager.getLogger(S3BucketBuilderImpl.class);
 
+	static final String INVENTORY_ID = "inventoryConfig";
+	static final String INVENTORY_FORMAT = "Parquet";
+	static final String INVENTORY_PREFIX = "inventory";
+	static final List<String> INVENTORY_FIELDS = Arrays.asList(
+			"Size", "LastModifiedDate", "ETag", "IsMultipartUploaded"
+	);
+	static final String RETENTION_RULE_ID = "retentionRule";
+	
+	private AmazonS3 s3Client;
+	private AWSSecurityTokenService stsClient;
+	private RepoConfiguration config;
+	private S3Config s3Config;
+	private VelocityEngine velocity;
+	
 	@Inject
-	public S3BucketBuilderImpl(AmazonS3 s3Client, RepoConfiguration configuration) {
-		super();
+	public S3BucketBuilderImpl(AmazonS3 s3Client, AWSSecurityTokenService stsClient, RepoConfiguration config, S3Config s3Config, VelocityEngine velocity) {
 		this.s3Client = s3Client;
-		this.config = configuration;
+		this.stsClient = stsClient;
+		this.config = config;
+		this.s3Config = s3Config;
+		this.velocity = velocity;
 	}
 
 	@Override
 	public void buildAllBuckets() {
 		String stack = config.getProperty(PROPERTY_KEY_STACK);
-		String[] buckets = config.getComaSeparatedProperty(PROPERTY_KEY_S3_BUCKETS_CSV);
-		for (String rawName : buckets) {
-			String bucketName = rawName.replace("${stack}", stack);
-			if(bucketName.contains("$")) {
-				throw new IllegalArgumentException("Unable to read bucket name: "+bucketName);
+		
+		String accountId = stsClient.getCallerIdentity(new GetCallerIdentityRequest()).getAccount();
+		
+		String inventoryBucket = replaceStackVariable(s3Config.getInventoryBucket(), stack);
+		List<String> inventoriedBuckets = new ArrayList<>();
+		
+		// Configure all buckets first
+		for (S3BucketDescriptor bucket : s3Config.getBuckets()) {
+			String bucketName = replaceStackVariable(bucket.getName(), stack);
+			
+			createBucket(bucketName);
+			configureEncryption(bucketName);	
+			configureInventory(bucketName, accountId, inventoryBucket, bucket.isInventoryEnabled());
+			configureBucketLifeCycle(bucketName, bucket.getRetentionDays());
+			
+			if (bucket.isInventoryEnabled()) {
+				inventoriedBuckets.add(bucketName);
 			}
-			System.out.println("Creating bucket: "+bucketName);
-			s3Client.createBucket(bucketName);
-			try {
-				// If server side encryption is not currently set this call with throw a 404
-				s3Client.getBucketEncryption(bucketName);
-			} catch (AmazonServiceException e) {
-				if(e.getStatusCode() == 404) {
-					// The bucket is not currently encrypted so configure it for encryption.
-					System.out.println("Setting server side encryption for bucket: "+bucketName);
-					s3Client.setBucketEncryption(new SetBucketEncryptionRequest().withBucketName(bucketName)
-							.withServerSideEncryptionConfiguration(new ServerSideEncryptionConfiguration()
-									.withRules(new ServerSideEncryptionRule().withApplyServerSideEncryptionByDefault(
-											new ServerSideEncryptionByDefault().withSSEAlgorithm(SSEAlgorithm.AES256)))));
-				}else {
-					throw e;
-				}
-			} 
+			
 		}
+		
+		// Makes sure the bucket policy on the inventory is correct
+		configureInventoryBucketPolicy(stack, accountId, inventoryBucket, inventoriedBuckets);
+	}
+	
+	private String replaceStackVariable(String bucketName, String stack) {
+		if (bucketName == null) {
+			return null;
+		}
+		
+		bucketName = bucketName.replace("${stack}", stack);
+		
+		if(bucketName.contains("$")) {
+			throw new IllegalArgumentException("Unable to read bucket name: "+bucketName);
+		}
+		
+		return bucketName;
+	}
+	
+	private void createBucket(String bucketName) {
+		logger.info("Creating bucket: {}.", bucketName);
+		
+		// This is idempotent
+		s3Client.createBucket(bucketName);
+	}
+	
+	private void configureEncryption(String bucketName) {
+		try {
+			// If server side encryption is not currently set this call with throw a 404
+			s3Client.getBucketEncryption(bucketName);
+		} catch (AmazonServiceException e) {
+			if(e.getStatusCode() == 404) {
+				// The bucket is not currently encrypted so configure it for encryption.
+				logger.info("Setting server side encryption for bucket: {}.", bucketName);
+				
+				s3Client.setBucketEncryption(new SetBucketEncryptionRequest().withBucketName(bucketName)
+						.withServerSideEncryptionConfiguration(new ServerSideEncryptionConfiguration()
+								.withRules(new ServerSideEncryptionRule().withApplyServerSideEncryptionByDefault(
+										new ServerSideEncryptionByDefault().withSSEAlgorithm(SSEAlgorithm.AES256)))));
+			} else {
+				throw e;
+			}
+		} 
+	}
+	
+	private void configureInventory(String bucketName, String accountId, String inventoryBucket, boolean enabled) {
+		if (inventoryBucket == null) {
+			return;
+		}
+		
+		try {
+			s3Client.getBucketInventoryConfiguration(bucketName, INVENTORY_ID);
+		} catch (AmazonServiceException e) {
+			if (e.getStatusCode() == 404) {
+				// If the inventory was disabled and does not exists, we do not add a configuration
+				if (enabled) {
+					setInventoryConfiguration(bucketName, accountId, inventoryBucket);
+				}
+				return;
+			} else {
+				throw e;
+			}
+		}
+		
+		if (enabled) {
+			logger.warn("An inventory configuration for bucket {} exists already, will not update.", bucketName);
+		} else {
+			logger.info("Removing inventory configuration for bucket {}.", bucketName);
+			s3Client.deleteBucketInventoryConfiguration(bucketName, INVENTORY_ID);
+		}
+		
+	}
+	
+	private void setInventoryConfiguration(String bucketName, String accountId, String inventoryBucket) {
+		logger.info("Configuring inventory for bucket: {}.", bucketName);
+		
+		InventoryConfiguration config = new InventoryConfiguration()
+				.withId(INVENTORY_ID)
+				.withDestination(
+						new InventoryDestination()
+							.withS3BucketDestination(
+									new InventoryS3BucketDestination()
+										.withBucketArn("arn:aws:s3:::" + inventoryBucket)
+										.withAccountId(accountId)
+										.withPrefix(INVENTORY_PREFIX)
+										.withFormat(INVENTORY_FORMAT)
+							)
+				)
+				.withOptionalFields(INVENTORY_FIELDS)
+				.withSchedule(new InventorySchedule().withFrequency(InventoryFrequency.Weekly))
+				.withEnabled(true)
+				.withIncludedObjectVersions(InventoryIncludedObjectVersions.All);
+		
+		s3Client.setBucketInventoryConfiguration(bucketName, config);
+	}
+	
+	private void configureBucketLifeCycle(String bucketName, Integer retentionDays) {
+		if (retentionDays == null) {
+			return;
+		}
+		
+		// Returns null if no life cycle configuration was found
+		BucketLifecycleConfiguration config = s3Client.getBucketLifecycleConfiguration(bucketName);
+		
+		if (config != null) {
+			logger.warn("A bucket lifecycle configuration for bucket {} already exists, will not update.", bucketName);
+			return;
+		}
+		
+		config = new BucketLifecycleConfiguration()
+				.withRules(new BucketLifecycleConfiguration.Rule()
+						.withId(RETENTION_RULE_ID)
+						.withExpirationInDays(retentionDays)
+						.withStatus(BucketLifecycleConfiguration.ENABLED));
+		
+		logger.info("Configuring bucket {} lifecycle with {} days of retention.", bucketName, retentionDays);
+		
+		s3Client.setBucketLifecycleConfiguration(bucketName, config);
+		
+	}
+	
+	private void configureInventoryBucketPolicy(String stack, String accountId, String inventoryBucket, List<String> sourceBuckets) {
+		if (inventoryBucket == null) {
+			logger.warn("An inventory bucket was not specified.");
+			return;
+		} 
+		
+		if (sourceBuckets == null || sourceBuckets.isEmpty()) {
+			logger.warn("No bucket had the inventory enabled, removing bucket policy.");
+			s3Client.deleteBucketPolicy(inventoryBucket);
+			return;
+		}
+		
+		updateInventoryBucketPolicy(stack, accountId, inventoryBucket, sourceBuckets);
+		
+	}
+	
+	private void updateInventoryBucketPolicy(String stack, String accountId, String inventoryBucket, List<String> sourceBuckets) {
+		VelocityContext context = new VelocityContext();
+		
+		context.put("stack", stack);
+		context.put("accountId", accountId);
+		context.put("inventoryBucket", inventoryBucket);
+		context.put("sourceBuckets", sourceBuckets);
+		
+		Template policyTemplate = velocity.getTemplate(TEMPLATE_INVENTORY_BUCKET_POLICY_TEMPLATE);
+		
+		StringWriter stringWriter = new StringWriter();
+		
+		policyTemplate.merge(context, stringWriter);
+		
+		String jsonPolicy = stringWriter.toString();
+		
+		logger.info("Updating inventory bucket {} policy.", inventoryBucket);
+		
+		s3Client.setBucketPolicy(inventoryBucket, jsonPolicy);
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/template/s3/S3BucketDescriptor.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3BucketDescriptor.java
@@ -1,0 +1,76 @@
+package org.sagebionetworks.template.s3;
+
+import java.util.Objects;
+
+public class S3BucketDescriptor {
+
+	/**
+	 * The name of the bucket
+	 */
+	private String name;
+
+	/**
+	 * True if the an inventory configuration should be enabled for the bucket using the inventory bucket as destination
+	 */
+	private boolean inventoryEnabled = false;
+
+	/**
+	 * If set will setup a retention life cycle rule for the specified number of days
+	 */
+	private Integer retentionDays;
+
+	public S3BucketDescriptor() {
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public boolean isInventoryEnabled() {
+		return inventoryEnabled;
+	}
+
+	public void setInventoryEnabled(boolean inventoryEnabled) {
+		this.inventoryEnabled = inventoryEnabled;
+	}
+
+	public Integer getRetentionDays() {
+		return retentionDays;
+	}
+
+	public void setRetentionDays(Integer retentionDays) {
+		this.retentionDays = retentionDays;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(inventoryEnabled, name, retentionDays);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		S3BucketDescriptor other = (S3BucketDescriptor) obj;
+		return inventoryEnabled == other.inventoryEnabled && Objects.equals(name, other.name)
+				&& Objects.equals(retentionDays, other.retentionDays);
+	}
+
+	@Override
+	public String toString() {
+		return "S3BucketDescriptor [name=" + name + ", inventoryEnabled=" + inventoryEnabled + ", retentionDays="
+				+ retentionDays + "]";
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/template/s3/S3BuilderMain.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3BuilderMain.java
@@ -1,0 +1,16 @@
+package org.sagebionetworks.template.s3;
+
+import org.sagebionetworks.template.TemplateGuiceModule;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+public class S3BuilderMain {
+	
+	public static void main(String[] args) throws InterruptedException {
+		Injector injector = Guice.createInjector(new TemplateGuiceModule());
+		S3BucketBuilder builder = injector.getInstance(S3BucketBuilder.class);
+		builder.buildAllBuckets();
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/template/s3/S3Config.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3Config.java
@@ -1,0 +1,61 @@
+package org.sagebionetworks.template.s3;
+
+import java.util.List;
+import java.util.Objects;
+
+public class S3Config {
+
+	/**
+	 * The list of bucket descriptors
+	 */
+	private List<S3BucketDescriptor> buckets;
+
+	/**
+	 * The name of the bucket used as inventory if any
+	 */
+	private String inventoryBucket;
+
+	public S3Config() { }
+
+	public List<S3BucketDescriptor> getBuckets() {
+		return buckets;
+	}
+
+	public void setBuckets(List<S3BucketDescriptor> buckets) {
+		this.buckets = buckets;
+	}
+
+	public String getInventoryBucket() {
+		return inventoryBucket;
+	}
+
+	public void setInventoryBucket(String inventoryBucket) {
+		this.inventoryBucket = inventoryBucket;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(buckets, inventoryBucket);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		S3Config other = (S3Config) obj;
+		return Objects.equals(buckets, other.buckets) && Objects.equals(inventoryBucket, other.inventoryBucket);
+	}
+
+	@Override
+	public String toString() {
+		return "S3Config [buckets=" + buckets + ", inventoryBucket=" + inventoryBucket + "]";
+	}
+
+}

--- a/src/main/java/org/sagebionetworks/template/s3/S3ConfigValidator.java
+++ b/src/main/java/org/sagebionetworks/template/s3/S3ConfigValidator.java
@@ -1,0 +1,36 @@
+package org.sagebionetworks.template.s3;
+
+public class S3ConfigValidator {
+	
+	private S3Config config;
+	
+	public S3ConfigValidator(S3Config config) {
+		this.config = config;
+	}
+	
+	public S3Config validate() {
+		String inventoryBucket = config.getInventoryBucket();
+	
+		// Makes sure the inventory bucket is defined in the list
+		if (inventoryBucket != null ) {
+			config.getBuckets()
+				.stream()
+				.filter(bucket -> bucket.getName().equals(inventoryBucket))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("An inventory bucket is defined but was not in the list of buckets."));
+		} 
+		// If no inventory bucket is defined make sure that not bucket in the list requires an inventory
+		else {
+			config.getBuckets()
+				.stream()
+				.filter(bucket -> bucket.isInventoryEnabled())
+				.findAny()
+				.ifPresent(bucket -> {
+					throw new IllegalArgumentException("The bucket " + bucket.getName() + " has the inventoryEnabled but no inventoryBucket was defined.");
+				});
+		}
+		
+		return config;
+	}
+	
+}

--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -69,11 +69,3 @@ org.sagebionetworks.beanstalk.image.version.tomcat=8.5
 org.sagebionetworks.beanstalk.image.version.amazonlinux=3.3.9
 # The Synapse OAuth authorization endpoint
 org.sagebionetworks.oauth.authorization.endpoint=https://signin.synapse.org
-# The S3 buckets used by the stack.
-org.sagebionetworks.s3.buckets=${stack}.table.row.changes\
-,${stack}.access.record.sagebase.org\
-,${stack}.snapshot.record.sagebase.org\
-,${stack}.discussion.sagebase.org\
-,${stack}.log.sagebase.org\
-,${stack}.view.snapshots\
-

--- a/src/main/resources/templates/s3/s3-buckets-config.json
+++ b/src/main/resources/templates/s3/s3-buckets-config.json
@@ -1,0 +1,31 @@
+{
+	"buckets": [
+		{
+			"name": "${stack}.inventory.sagebase.org",
+			"retentionDays": 30
+		},
+		{
+			"name": "${stack}data.sagebase.org",
+			"inventoryEnabled": true
+		},
+		{
+			"name": "${stack}.table.row.changes"
+		},
+		{
+			"name": "${stack}.access.record.sagebase.org"
+		},
+		{
+			"name": "${stack}.snapshot.record.sagebase.org"
+		},
+		{
+			"name": "${stack}.discussion.sagebase.org"
+		},
+		{
+			"name": "${stack}.log.sagebase.org"
+		},
+		{
+			"name": "${stack}.view.snapshots"
+		}
+	],
+	"inventoryBucket": "${stack}.inventory.sagebase.org"
+}

--- a/src/main/resources/templates/s3/s3-inventory-bucket-policy.json.vpt
+++ b/src/main/resources/templates/s3/s3-inventory-bucket-policy.json.vpt
@@ -1,0 +1,21 @@
+{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"InventoryPolicy",
+      "Effect":"Allow",
+      "Principal": {"Service": "s3.amazonaws.com"},
+      "Action":"s3:PutObject",
+      "Resource":["arn:aws:s3:::$inventoryBucket/*"],
+      "Condition": {
+          "ArnLike": {
+              "aws:SourceArn": [#foreach($sourceBucket in $sourceBuckets)"arn:aws:s3:::$sourceBucket"#if($foreach.hasNext),#end#end]
+         },
+         "StringEquals": {
+             "aws:SourceAccount": "$accountId",
+             "s3:x-amz-acl": "bucket-owner-full-control"
+          }
+       }
+    }
+  ]
+}

--- a/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
@@ -26,18 +26,18 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_VERS
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_INSTANCE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OAUTH_ENDPOINT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_ALLOCATED_STORAGE;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_MAX_ALLOCATED_STORAGE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_INSTANCE_CLASS;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_IOPS;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_MAX_ALLOCATED_STORAGE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_MULTI_AZ;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPO_RDS_STORAGE_TYPE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ROUTE_53_HOSTED_ZONE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_INSTANCE_COUNT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_ALLOCATED_STORAGE;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_MAX_ALLOCATED_STORAGE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_INSTANCE_CLASS;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_IOPS;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_MAX_ALLOCATED_STORAGE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_STORAGE_TYPE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_VPC_SUBNET_COLOR;
 import static org.sagebionetworks.template.Constants.REPO_BEANSTALK_NUMBER;
@@ -116,8 +116,6 @@ public class RepositoryTemplateBuilderImplTest {
 	@Mock
 	StackTagsProvider mockStackTagsProvider;
 	@Mock
-	S3BucketBuilder mockBucketBuilder;
-	@Mock
 	CloudwatchLogsVelocityContextProvider mockCwlContextProvider;
 	@Captor
 	ArgumentCaptor<CreateOrUpdateStackRequest> requestCaptor;
@@ -154,7 +152,7 @@ public class RepositoryTemplateBuilderImplTest {
 
 		builder = new RepositoryTemplateBuilderImpl(mockCloudFormationClient, velocityEngine, config, mockLoggerFactory,
 				mockArtifactCopy, mockSecretBuilder, mockACLBuilder, Sets.newHashSet(mockContextProvider1, mockContextProvider2),
-				mockElasticBeanstalkDefaultAMIEncrypter, mockStackTagsProvider, mockBucketBuilder, mockCwlContextProvider);
+				mockElasticBeanstalkDefaultAMIEncrypter, mockStackTagsProvider, mockCwlContextProvider);
 
 		stack = "dev";
 		instance = "101";
@@ -251,7 +249,6 @@ public class RepositoryTemplateBuilderImplTest {
 		configureStack(stack);
 		// call under test
 		builder.buildAndDeploy();
-		verify(mockBucketBuilder).buildAllBuckets();
 		verify(mockCloudFormationClient, times(4)).createOrUpdateStack(requestCaptor.capture());
 		List<CreateOrUpdateStackRequest> list = requestCaptor.getAllValues();
 		CreateOrUpdateStackRequest request = list.get(0);
@@ -292,7 +289,6 @@ public class RepositoryTemplateBuilderImplTest {
 		configureStack(stack);
 		// call under test
 		builder.buildAndDeploy();
-		verify(mockBucketBuilder).buildAllBuckets();
 		verify(mockCloudFormationClient, times(4)).createOrUpdateStack(requestCaptor.capture());
 		List<CreateOrUpdateStackRequest> list = requestCaptor.getAllValues();
 		CreateOrUpdateStackRequest request = list.get(0);

--- a/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,9 +15,6 @@ import static org.sagebionetworks.template.Constants.ENVIRONMENT;
 import static org.sagebionetworks.template.Constants.INSTANCE;
 import static org.sagebionetworks.template.Constants.OUTPUT_NAME_SUFFIX_REPOSITORY_DB_ENDPOINT;
 import static org.sagebionetworks.template.Constants.PARAMETER_MYSQL_PASSWORD;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_AWS_ACCESS_KEY_ID;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_AWS_SECRET_KEY;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_ENCRYPTION_KEY;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_HEALTH_CHECK_URL;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_MAX_INSTANCES;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_MIN_INSTANCES;
@@ -63,7 +60,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.sagebionetworks.template.CloudFormationClient;
 import org.sagebionetworks.template.ConfigurationPropertyNotFound;
 import org.sagebionetworks.template.CreateOrUpdateStackRequest;
@@ -194,10 +191,6 @@ public class RepositoryTemplateBuilderImplTest {
 
 		when(config.getProperty((PROPERTY_KEY_OAUTH_ENDPOINT))).thenReturn("https://oauthendpoint");
 
-		when(config.getProperty(PROPERTY_KEY_AWS_ACCESS_KEY_ID)).thenReturn("aws-key");
-		when(config.getProperty(PROPERTY_KEY_AWS_SECRET_KEY)).thenReturn("aws-secret");
-		when(config.getProperty(PROPERTY_KEY_BEANSTALK_ENCRYPTION_KEY)).thenReturn("encryption-key");
-
 		sharedResouces = new Stack();
 		Output dbOut = new Output();
 		dbOut.withOutputKey(stack+instance+OUTPUT_NAME_SUFFIX_REPOSITORY_DB_ENDPOINT);
@@ -212,8 +205,6 @@ public class RepositoryTemplateBuilderImplTest {
 		tableDBOutput2.withOutputValue(stack+"-"+instance+"-table-1."+databaseEndpointSuffix);
 
 		sharedResouces.withOutputs(dbOut, tableDBOutput1, tableDBOutput2);
-
-		when(mockCloudFormationClient.waitForStackToComplete(any(String.class))).thenReturn(sharedResouces);
 		
 		secretsSouce = new SourceBundle("secretBucket", "secretKey");
 		keyAlias = "alias/some/alias";
@@ -306,7 +297,7 @@ public class RepositoryTemplateBuilderImplTest {
 		verify(mockCwlContextProvider).getLogDescriptors(EnvironmentType.REPOSITORY_SERVICES);
 		verify(mockCwlContextProvider).getLogDescriptors(EnvironmentType.REPOSITORY_WORKERS);
 		verify(mockCwlContextProvider).getLogDescriptors(EnvironmentType.PORTAL);
-
+		
 		// dev should not have alarms
 		assertFalse(resources.has("dev101Table1RepositoryDBAlarmSwapUsage"));
 		assertFalse(resources.has("dev101Table1RepositoryDBAlarmSwapUsage"));

--- a/src/test/java/org/sagebionetworks/template/repo/beanstalk/ssl/ElasticBeanstalkExtentionBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/beanstalk/ssl/ElasticBeanstalkExtentionBuilderImplTest.java
@@ -79,7 +79,7 @@ public class ElasticBeanstalkExtentionBuilderImplTest {
 		doAnswer(new Answer<File>() {
 			@Override
 			public File answer(InvocationOnMock invocation) throws Throwable {
-				Consumer<File> consumer = invocation.getArgumentAt(1, Consumer.class);
+				Consumer<File> consumer = invocation.getArgument(1, Consumer.class);
 				// forward the request to the consumer
 				consumer.accept(mockTempDirectory);
 				return mockWarCopy;

--- a/src/test/java/org/sagebionetworks/template/repo/cloudwatchlogs/CloudwatchLogsConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/cloudwatchlogs/CloudwatchLogsConfigTest.java
@@ -1,14 +1,12 @@
 package org.sagebionetworks.template.repo.cloudwatchlogs;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.Test;
 import org.sagebionetworks.template.TemplateGuiceModule;
-import org.sagebionetworks.template.repo.beanstalk.EnvironmentType;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 
 public class CloudwatchLogsConfigTest {
 

--- a/src/test/java/org/sagebionetworks/template/repo/cloudwatchlogs/CloudwatchLogsConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/cloudwatchlogs/CloudwatchLogsConfigValidatorTest.java
@@ -1,21 +1,18 @@
 package org.sagebionetworks.template.repo.cloudwatchlogs;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.sagebionetworks.template.repo.beanstalk.EnvironmentType;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.sagebionetworks.template.repo.beanstalk.EnvironmentType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CloudwatchLogsConfigValidatorTest {

--- a/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseConfigTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.template.repo.kinesis;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sagebionetworks.template.TemplateGuiceModule;
 import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseConfig;
 

--- a/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseConfigValidatorTest.java
@@ -1,14 +1,15 @@
 package org.sagebionetworks.template.repo.kinesis;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.template.repo.kinesis.firehose.GlueTableDescriptor;
 import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseConfig;
 import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseConfigValidator;
@@ -17,7 +18,7 @@ import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseStreamD
 
 import com.google.common.collect.ImmutableMap;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KinesisFirehoseConfigValidatorTest {
 
 	@Mock
@@ -52,7 +53,7 @@ public class KinesisFirehoseConfigValidatorTest {
 		validator.validate();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testWithEmptyColumnDef() {
 
 		GlueTableDescriptor table = new GlueTableDescriptor();
@@ -64,21 +65,25 @@ public class KinesisFirehoseConfigValidatorTest {
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
 
-		validator.validate();
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testWithMissingTableDescriptorForParquet() {
 
 		KinesisFirehoseStreamDescriptor stream = new KinesisFirehoseStreamDescriptor();
 		stream.setFormat(KinesisFirehoseRecordFormat.PARQUET);
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
-
-		validator.validate();
+		
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testWithLowBufferInterval() {
 
 		KinesisFirehoseStreamDescriptor stream = new KinesisFirehoseStreamDescriptor();
@@ -86,11 +91,13 @@ public class KinesisFirehoseConfigValidatorTest {
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
 
-		validator.validate();
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testWithHighBufferInterval() {
 
 		KinesisFirehoseStreamDescriptor stream = new KinesisFirehoseStreamDescriptor();
@@ -98,11 +105,13 @@ public class KinesisFirehoseConfigValidatorTest {
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
 
-		validator.validate();
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 
 	}
-	
-	@Test(expected = IllegalStateException.class)
+
+	@Test
 	public void testWithLowBufferSize() {
 
 		KinesisFirehoseStreamDescriptor stream = new KinesisFirehoseStreamDescriptor();
@@ -110,11 +119,13 @@ public class KinesisFirehoseConfigValidatorTest {
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
 
-		validator.validate();
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testWithHighBufferSize() {
 
 		KinesisFirehoseStreamDescriptor stream = new KinesisFirehoseStreamDescriptor();
@@ -122,7 +133,9 @@ public class KinesisFirehoseConfigValidatorTest {
 
 		when(mockConfig.getStreamDescriptors()).thenReturn(Collections.singleton(stream));
 
-		validator.validate();
+		assertThrows(IllegalStateException.class, () -> {
+			validator.validate();
+		});
 
 	}
 

--- a/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseVelocityContextProviderTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/kinesis/KinesisFirehoseVelocityContextProviderTest.java
@@ -12,13 +12,12 @@ import java.util.Collections;
 import java.util.Set;
 
 import org.apache.velocity.VelocityContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.template.config.RepoConfiguration;
 import org.sagebionetworks.template.repo.kinesis.firehose.GlueTableDescriptor;
 import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseConfig;
@@ -27,7 +26,7 @@ import org.sagebionetworks.template.repo.kinesis.firehose.KinesisFirehoseVelocit
 
 import com.google.common.collect.ImmutableSet;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class KinesisFirehoseVelocityContextProviderTest {
 
 	@Mock
@@ -55,11 +54,9 @@ public class KinesisFirehoseVelocityContextProviderTest {
 	private String testInstance = "TestInstance";
 	private Set<KinesisFirehoseStreamDescriptor> testStreams;
 	
-	@Before
+	@BeforeEach
 	public void before() {
-		MockitoAnnotations.initMocks(this);
 		testStreams = Collections.singleton(mockStream);
-		when(mockStream.isDevOnly()).thenReturn(false);
 		when(mockRepoConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(testStack);
 		when(mockRepoConfig.getProperty(PROPERTY_KEY_INSTANCE)).thenReturn(testInstance);
 		when(mockStream.getTableDescriptor()).thenReturn(mockTable);
@@ -94,30 +91,10 @@ public class KinesisFirehoseVelocityContextProviderTest {
 		String devStack = "someOtherStack";
 		
 		when(mockRepoConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(devStack);
-		when(mockStream.isDevOnly()).thenReturn(true);
 		
 		contextProvider.addToContext(mockContext);
 		
 		verify(mockContext).put(KINESIS_FIREHOSE_STREAM_DESCRIPTORS, Collections.singleton(mockStream));
-	}
-	
-	@Test
-	public void testAddToContextWithDevOnlyStreamsMixed() {
-		
-		// A stack different than prod
-		String prodStack = "someOtherStack";
-		
-		// Second stream is dev only
-		when(mockStream2.isDevOnly()).thenReturn(true);
-		
-		Set<KinesisFirehoseStreamDescriptor> streams = ImmutableSet.of(mockStream, mockStream2);
-		
-		when(mockConfig.getStreamDescriptors()).thenReturn(streams);
-		when(mockRepoConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(prodStack);
-		
-		contextProvider.addToContext(mockContext);
-		
-		verify(mockContext).put(KINESIS_FIREHOSE_STREAM_DESCRIPTORS, streams);
 	}
 	
 	@Test

--- a/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderImplTest.java
@@ -1,12 +1,14 @@
-package org.sagebionetworks.template.repo;
+package org.sagebionetworks.template.s3;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_S3_BUCKETS_CSV;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 

--- a/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderImplTest.java
@@ -1,83 +1,153 @@
 package org.sagebionetworks.template.s3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_S3_BUCKETS_CSV;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.io.StringWriter;
+import java.util.Arrays;
+
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 import org.sagebionetworks.template.config.RepoConfiguration;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration.Rule;
+import com.amazonaws.services.s3.model.GetBucketInventoryConfigurationResult;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
 import com.amazonaws.services.s3.model.ServerSideEncryptionRule;
 import com.amazonaws.services.s3.model.SetBucketEncryptionRequest;
+import com.amazonaws.services.s3.model.inventory.InventoryConfiguration;
+import com.amazonaws.services.s3.model.inventory.InventoryFrequency;
+import com.amazonaws.services.s3.model.inventory.InventoryS3BucketDestination;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
 
-
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class S3BucketBuilderImplTest {
 
 	@Mock
-	RepoConfiguration mockConfig;
+	private RepoConfiguration mockConfig;
+
 	@Mock
-	AmazonS3 mockS3Client;
-	@Captor
-	ArgumentCaptor<SetBucketEncryptionRequest> encryptionRequestCaptor;
-	
+	private S3Config mockS3Config;
+
+	@Mock
+	private AmazonS3 mockS3Client;
+
+	@Mock
+	private AWSSecurityTokenService mockStsClient;
+
+	@Mock
+	private VelocityEngine mockVelocity;
+
 	@InjectMocks
-	S3BucketBuilderImpl builder;
+	private S3BucketBuilderImpl builder;
+
+	@Mock
+	private GetCallerIdentityResult mockGetCallerIdentityResult;
 	
-	@Test
-	public void testBuildAllBucketsAlreadyEncrypted() {
-		String[] rawBucketNames = new String[] {"${stack}.one", "${stack}.two"};
-		when(mockConfig.getComaSeparatedProperty(PROPERTY_KEY_S3_BUCKETS_CSV)).thenReturn(rawBucketNames);
-		String stack = "dev";
-		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+	@Mock
+	private Template mockTemplate;
+
+	@Captor
+	private ArgumentCaptor<SetBucketEncryptionRequest> encryptionRequestCaptor;
+	
+	@Captor
+	private ArgumentCaptor<InventoryConfiguration> inventoryConfigurationCaptor;
+	
+	@Captor
+	private ArgumentCaptor<BucketLifecycleConfiguration> bucketLifeCycleConfigurationCaptor;
+	
+	@Captor
+	private ArgumentCaptor<VelocityContext> velocityContextCaptor;
+
+	private String stack;
+	private String accountId;
+
+	@BeforeEach
+	public void before() {
+		stack = "dev";
+		accountId = "12345";
 		
-		// call under test
-		builder.buildAllBuckets();
-		verify(mockS3Client).createBucket("dev.one");
-		verify(mockS3Client).getBucketEncryption("dev.one");
-		verify(mockS3Client).createBucket("dev.two");
-		verify(mockS3Client).getBucketEncryption("dev.two");
-		verify(mockS3Client, never()).setBucketEncryption(any(SetBucketEncryptionRequest.class));
+		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+		when(mockStsClient.getCallerIdentity(any())).thenReturn(mockGetCallerIdentityResult);
+		when(mockGetCallerIdentityResult.getAccount()).thenReturn(accountId);
 	}
-	
-	
+
+	@Test
+	public void testBuildAllBuckets() {
+
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(bucket));
+
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+
+		verify(mockS3Client, never()).setBucketEncryption(any());
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).deleteBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).getBucketLifecycleConfiguration(anyString());
+		verify(mockS3Client, never()).setBucketLifecycleConfiguration(any(), any());
+		verify(mockS3Client, never()).setBucketPolicy(any(), any());
+
+	}
+
 	@Test
 	public void testBuildAllBucketsNeedsEncypted() {
-		String[] rawBucketNames = new String[] {"${stack}.one"};
-		when(mockConfig.getComaSeparatedProperty(PROPERTY_KEY_S3_BUCKETS_CSV)).thenReturn(rawBucketNames);
-		String stack = "dev";
-		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
 		
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(bucket));
+
 		AmazonServiceException notFound = new AmazonServiceException("NotFound");
 		notFound.setStatusCode(404);
-		doThrow(notFound).when(mockS3Client).getBucketEncryption("dev.one");
-		
+
+		doThrow(notFound).when(mockS3Client).getBucketEncryption(anyString());
+
+		String expectedBucketName = stack + ".bucket";
+
 		// call under test
 		builder.buildAllBuckets();
-		
-		verify(mockS3Client).createBucket("dev.one");
-		verify(mockS3Client).getBucketEncryption("dev.one");
+
+		verify(mockS3Client).createBucket(expectedBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
 		verify(mockS3Client).setBucketEncryption(encryptionRequestCaptor.capture());
+
 		SetBucketEncryptionRequest request = encryptionRequestCaptor.getValue();
+
 		assertNotNull(request);
-		assertEquals("dev.one",request.getBucketName());
+		assertEquals(expectedBucketName, request.getBucketName());
 		assertNotNull(request.getServerSideEncryptionConfiguration());
 		assertNotNull(request.getServerSideEncryptionConfiguration().getRules());
 		assertEquals(1, request.getServerSideEncryptionConfiguration().getRules().size());
@@ -85,53 +155,296 @@ public class S3BucketBuilderImplTest {
 		assertNotNull(rule.getApplyServerSideEncryptionByDefault());
 		assertEquals(SSEAlgorithm.AES256.name(), rule.getApplyServerSideEncryptionByDefault().getSSEAlgorithm());
 		
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).deleteBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).getBucketLifecycleConfiguration(anyString());
+		verify(mockS3Client, never()).setBucketLifecycleConfiguration(any(), any());
+		verify(mockS3Client, never()).setBucketPolicy(any(), any());
+
 	}
-	
-	@Test
-	public void testBuildAllBucketsUnknowError() {
-		String[] rawBucketNames = new String[] {"${stack}.one"};
-		when(mockConfig.getComaSeparatedProperty(PROPERTY_KEY_S3_BUCKETS_CSV)).thenReturn(rawBucketNames);
-		String stack = "dev";
-		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
-		
-		// some other exception
-		AmazonServiceException exception = new AmazonServiceException("some other error");
-		exception.setStatusCode(500);
-		doThrow(exception).when(mockS3Client).getBucketEncryption("dev.one");
-		
-		try {
-			// call under test
-			builder.buildAllBuckets();
-			fail();
-		} catch (Exception e) {
-			assertEquals(exception, e);
-		}
-		
-		verify(mockS3Client).createBucket("dev.one");
-		verify(mockS3Client).getBucketEncryption("dev.one");
-		verify(mockS3Client, never()).setBucketEncryption(any(SetBucketEncryptionRequest.class));
-		
-	}
-	
+
 	@Test
 	public void testBuildAllBucketsBadName() {
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
 		// bad name
-		String[] rawBucketNames = new String[] {"${stack}.${instance}.one"};
-		when(mockConfig.getComaSeparatedProperty(PROPERTY_KEY_S3_BUCKETS_CSV)).thenReturn(rawBucketNames);
-		String stack = "dev";
-		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+		bucket.setName("${stack}.${instance}.one");
 		
-		try {
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(bucket));
+		
+		assertThrows(IllegalArgumentException.class, () -> {
 			// call under test
 			builder.buildAllBuckets();
-			fail();
-		} catch (IllegalArgumentException e) {
-			// expected
-		}
+		});
+
+		verifyNoMoreInteractions(mockS3Client);
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithInventory() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("${stack}.inventory");
 		
-		verify(mockS3Client, never()).createBucket(anyString());
-		verify(mockS3Client, never()).getBucketEncryption(anyString());
-		verify(mockS3Client, never()).setBucketEncryption(any(SetBucketEncryptionRequest.class));
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setInventoryEnabled(true);
 		
+		String expectedInventoryBucketName = stack + ".inventory";
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucket));
+		
+		AmazonServiceException notFound = new AmazonServiceException("NotFound");
+		notFound.setStatusCode(404);
+
+		// No inventory configuration set
+		doThrow(notFound).when(mockS3Client).getBucketInventoryConfiguration(anyString(), anyString());
+		
+		when(mockVelocity.getTemplate(any())).thenReturn(mockTemplate);
+		
+		doAnswer(new Answer<Void>() {
+			@Override
+			public Void answer(InvocationOnMock invocation) throws Throwable {
+				StringWriter writer = (StringWriter) invocation.getArgument(1);
+				writer.append("fakeJsonPolicy");
+				return null;
+			}
+		}).when(mockTemplate).merge(any(), any());
+		
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedInventoryBucketName);
+		verify(mockS3Client).createBucket(expectedBucketName);
+		
+		verify(mockS3Client).getBucketEncryption(expectedInventoryBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		
+		verify(mockS3Client).getBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+
+		verify(mockS3Client).setBucketInventoryConfiguration(eq(expectedBucketName), inventoryConfigurationCaptor.capture());
+		
+		InventoryConfiguration config = inventoryConfigurationCaptor.getValue();
+		
+		assertEquals(S3BucketBuilderImpl.INVENTORY_ID, config.getId());
+		assertEquals(S3BucketBuilderImpl.INVENTORY_FIELDS, config.getOptionalFields());
+		assertEquals(InventoryFrequency.Weekly.toString(), config.getSchedule().getFrequency());
+		
+		InventoryS3BucketDestination destination = config.getDestination().getS3BucketDestination();
+		
+		assertEquals("arn:aws:s3:::" + expectedInventoryBucketName, destination.getBucketArn());
+		assertEquals(S3BucketBuilderImpl.INVENTORY_PREFIX, destination.getPrefix());
+		assertEquals(accountId, destination.getAccountId());
+		assertEquals(S3BucketBuilderImpl.INVENTORY_FORMAT, destination.getFormat());
+		
+		verify(mockS3Client, never()).deleteBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).getBucketLifecycleConfiguration(anyString());
+		verify(mockS3Client, never()).setBucketLifecycleConfiguration(any(), any());
+		
+		verify(mockTemplate).merge(velocityContextCaptor.capture(), any());
+		
+		VelocityContext context = velocityContextCaptor.getValue();
+		
+		assertEquals(stack, context.get("stack"));
+		assertEquals(accountId, context.get("accountId"));
+		assertEquals(expectedInventoryBucketName, context.get("inventoryBucket"));
+		assertEquals(Arrays.asList(expectedBucketName), context.get("sourceBuckets"));
+		
+		verify(mockS3Client).setBucketPolicy(expectedInventoryBucketName, "fakeJsonPolicy");
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithInventoryAndExisting() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("${stack}.inventory");
+		
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setInventoryEnabled(true);
+		
+		String expectedInventoryBucketName = stack + ".inventory";
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucket));
+		
+		// Mimics an existing configuration that is enabled
+		when(mockS3Client.getBucketInventoryConfiguration(anyString(), anyString())).thenReturn(
+				new GetBucketInventoryConfigurationResult().withInventoryConfiguration(
+						new InventoryConfiguration()
+						.withEnabled(true))
+		);
+		
+		when(mockVelocity.getTemplate(any())).thenReturn(mockTemplate);
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedInventoryBucketName);
+		verify(mockS3Client).createBucket(expectedBucketName);
+		
+		verify(mockS3Client).getBucketEncryption(expectedInventoryBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		
+		verify(mockS3Client).getBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client, never()).deleteBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithDisabledInventoryAndNonExisting() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("${stack}.inventory");
+		
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setInventoryEnabled(false);
+		
+		String expectedInventoryBucketName = stack + ".inventory";
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucket));
+		
+		AmazonServiceException notFound = new AmazonServiceException("NotFound");
+		notFound.setStatusCode(404);
+
+		// No inventory configuration set
+		doThrow(notFound).when(mockS3Client).getBucketInventoryConfiguration(anyString(), anyString());
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedInventoryBucketName);
+		verify(mockS3Client).createBucket(expectedBucketName);
+		
+		verify(mockS3Client).getBucketEncryption(expectedInventoryBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		
+		verify(mockS3Client).getBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		// No bucket was setup to have the inventory, delete the bucket policy
+		verify(mockS3Client).deleteBucketPolicy(expectedInventoryBucketName);
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithDisabledInventoryAndExisting() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("${stack}.inventory");
+		
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setInventoryEnabled(false);
+		
+		String expectedInventoryBucketName = stack + ".inventory";
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucket));
+		
+		// Mimics an existing configuration that is enabled
+		when(mockS3Client.getBucketInventoryConfiguration(anyString(), anyString())).thenReturn(
+				new GetBucketInventoryConfigurationResult().withInventoryConfiguration(
+						new InventoryConfiguration()
+						.withEnabled(true))
+		);
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedInventoryBucketName);
+		verify(mockS3Client).createBucket(expectedBucketName);
+		
+		verify(mockS3Client).getBucketEncryption(expectedInventoryBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		
+		verify(mockS3Client).getBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		verify(mockS3Client).deleteBucketInventoryConfiguration(expectedBucketName, S3BucketBuilderImpl.INVENTORY_ID);
+		// No bucket was setup to have the inventory, delete the bucket policy
+		verify(mockS3Client).deleteBucketPolicy(expectedInventoryBucketName);
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithRetentionDays() {
+
+		
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setRetentionDays(30);
+		
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(bucket));
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		verify(mockS3Client).getBucketLifecycleConfiguration(expectedBucketName);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		
+		verify(mockS3Client).setBucketLifecycleConfiguration(eq(expectedBucketName), bucketLifeCycleConfigurationCaptor.capture());
+		
+		BucketLifecycleConfiguration config = bucketLifeCycleConfigurationCaptor.getValue();
+		
+		assertEquals(1, config.getRules().size());
+
+		Rule rule = config.getRules().get(0);
+		
+		assertEquals(S3BucketBuilderImpl.RETENTION_RULE_ID, rule.getId());
+		assertEquals(bucket.getRetentionDays(), rule.getExpirationInDays());
+		assertEquals(BucketLifecycleConfiguration.ENABLED, rule.getStatus());
+
+	}
+	
+	@Test
+	public void testBuildAllBucketsWithRetentionDaysAndExistingLifeCycle() {
+
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("${stack}.bucket");
+		bucket.setRetentionDays(30);
+		
+		String expectedBucketName = stack + ".bucket";
+		
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(bucket));
+		
+		// Mimics an existing life cycle set on the bucket already
+		when(mockS3Client.getBucketLifecycleConfiguration(anyString())).thenReturn(new BucketLifecycleConfiguration());
+		
+		// Call under test
+		builder.buildAllBuckets();
+
+		verify(mockS3Client).createBucket(expectedBucketName);
+		verify(mockS3Client).getBucketEncryption(expectedBucketName);
+		verify(mockS3Client).getBucketLifecycleConfiguration(expectedBucketName);
+		
+		verify(mockS3Client, never()).setBucketEncryption(any());
+		verify(mockS3Client, never()).setBucketInventoryConfiguration(any(), any());
+		
+		verify(mockS3Client, never()).setBucketLifecycleConfiguration(any(), any());
 	}
 }

--- a/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderIntegrationTest.java
+++ b/src/test/java/org/sagebionetworks/template/s3/S3BucketBuilderIntegrationTest.java
@@ -1,0 +1,157 @@
+package org.sagebionetworks.template.s3;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
+
+import java.util.Arrays;
+
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sagebionetworks.template.TemplateGuiceModule;
+import org.sagebionetworks.template.config.RepoConfiguration;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
+@ExtendWith(MockitoExtension.class)
+public class S3BucketBuilderIntegrationTest {
+	
+	@Mock
+	private RepoConfiguration mockConfig;
+
+	@Mock
+	private S3Config mockS3Config;
+
+	@Mock
+	private AmazonS3 mockS3Client;
+
+	@Mock
+	private AWSSecurityTokenService mockStsClient;
+	
+	@Mock
+	private GetCallerIdentityResult mockGetCallerIdentityResult;
+	
+	@Captor
+	private ArgumentCaptor<String> stringCaptor;
+
+	private S3BucketBuilderImpl builder;
+	private String stack;
+	private String accountId;
+	
+	@BeforeEach
+	public void before() {
+		Injector injector = Guice.createInjector(new TemplateGuiceModule());
+		VelocityEngine velocityEngine = injector.getInstance(VelocityEngine.class);
+		
+		builder = new S3BucketBuilderImpl(mockS3Client, mockStsClient, mockConfig, mockS3Config, velocityEngine);
+		
+		stack = "dev";
+		accountId = "12345";
+		
+		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+		when(mockStsClient.getCallerIdentity(any())).thenReturn(mockGetCallerIdentityResult);
+		when(mockGetCallerIdentityResult.getAccount()).thenReturn(accountId);
+	}
+
+	@Test
+	public void testInventoryBucketPolicy() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("dev.inventory");
+		
+		S3BucketDescriptor bucket = new S3BucketDescriptor();
+		bucket.setName("dev.bucket");
+		bucket.setInventoryEnabled(true);
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucket));
+		
+		String expectedPolicy = "{\n"
+				+ "  \"Version\":\"2012-10-17\",\n"
+				+ "  \"Statement\":[\n"
+				+ "    {\n"
+				+ "      \"Sid\":\"InventoryPolicy\",\n"
+				+ "      \"Effect\":\"Allow\",\n"
+				+ "      \"Principal\": {\"Service\": \"s3.amazonaws.com\"},\n"
+				+ "      \"Action\":\"s3:PutObject\",\n"
+				+ "      \"Resource\":[\"arn:aws:s3:::dev.inventory/*\"],\n"
+				+ "      \"Condition\": {\n"
+				+ "          \"ArnLike\": {\n"
+				+ "              \"aws:SourceArn\": [\"arn:aws:s3:::dev.bucket\"]\n"
+				+ "         },\n"
+				+ "         \"StringEquals\": {\n"
+				+ "             \"aws:SourceAccount\": \"12345\",\n"
+				+ "             \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n"
+				+ "          }\n"
+				+ "       }\n"
+				+ "    }\n"
+				+ "  ]\n"
+				+ "}";
+		
+		// Call under test
+		builder.buildAllBuckets();
+		
+		verify(mockS3Client).setBucketPolicy("dev.inventory", expectedPolicy);
+		
+	}
+	
+	@Test
+	public void testInventoryBucketPolicyWithMultipleBuckets() {
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName("dev.inventory");
+		
+		S3BucketDescriptor bucketOne = new S3BucketDescriptor();
+		bucketOne.setName("dev.bucketOne");
+		bucketOne.setInventoryEnabled(true);
+		
+
+		S3BucketDescriptor bucketTwo = new S3BucketDescriptor();
+		bucketTwo.setName("dev.bucketTwo");
+		bucketTwo.setInventoryEnabled(true);
+		
+		
+		when(mockS3Config.getInventoryBucket()).thenReturn(inventoryBucket.getName());
+		when(mockS3Config.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, bucketOne, bucketTwo));
+		
+		String expectedPolicy = "{\n"
+				+ "  \"Version\":\"2012-10-17\",\n"
+				+ "  \"Statement\":[\n"
+				+ "    {\n"
+				+ "      \"Sid\":\"InventoryPolicy\",\n"
+				+ "      \"Effect\":\"Allow\",\n"
+				+ "      \"Principal\": {\"Service\": \"s3.amazonaws.com\"},\n"
+				+ "      \"Action\":\"s3:PutObject\",\n"
+				+ "      \"Resource\":[\"arn:aws:s3:::dev.inventory/*\"],\n"
+				+ "      \"Condition\": {\n"
+				+ "          \"ArnLike\": {\n"
+				+ "              \"aws:SourceArn\": [\"arn:aws:s3:::dev.bucketOne\",\"arn:aws:s3:::dev.bucketTwo\"]\n"
+				+ "         },\n"
+				+ "         \"StringEquals\": {\n"
+				+ "             \"aws:SourceAccount\": \"12345\",\n"
+				+ "             \"s3:x-amz-acl\": \"bucket-owner-full-control\"\n"
+				+ "          }\n"
+				+ "       }\n"
+				+ "    }\n"
+				+ "  ]\n"
+				+ "}";
+		
+		// Call under test
+		builder.buildAllBuckets();
+		
+		verify(mockS3Client).setBucketPolicy("dev.inventory", expectedPolicy);
+		
+	}
+	
+}

--- a/src/test/java/org/sagebionetworks/template/s3/S3ConfigValidatorTest.java
+++ b/src/test/java/org/sagebionetworks/template/s3/S3ConfigValidatorTest.java
@@ -1,0 +1,82 @@
+package org.sagebionetworks.template.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class S3ConfigValidatorTest {
+
+	@Mock
+	private S3Config mockConfig;
+
+	@InjectMocks
+	private S3ConfigValidator validator;
+
+	@Test
+	public void testValidate() {
+		String inventoryBucketName = "inventory";
+
+		S3BucketDescriptor inventoryBucket = new S3BucketDescriptor();
+		inventoryBucket.setName(inventoryBucketName);
+
+		S3BucketDescriptor anotherBucket = new S3BucketDescriptor();
+		anotherBucket.setName("antoherBucket");
+		anotherBucket.setInventoryEnabled(true);
+
+		when(mockConfig.getInventoryBucket()).thenReturn(inventoryBucketName);
+		when(mockConfig.getBuckets()).thenReturn(Arrays.asList(inventoryBucket, anotherBucket));
+
+		// Call under test
+		validator.validate();
+	}
+
+	@Test
+	public void testValidateWithNoInventoryDefinedAndInventoryEnabled() {
+		String inventoryBucketName = null;
+
+		S3BucketDescriptor anotherBucket = new S3BucketDescriptor();
+		anotherBucket.setName("antoherBucket");
+		
+		// The inventory is enabled for this bucket, but not inventory bucket was defined
+		anotherBucket.setInventoryEnabled(true);
+
+		when(mockConfig.getInventoryBucket()).thenReturn(inventoryBucketName);
+		when(mockConfig.getBuckets()).thenReturn(Arrays.asList(anotherBucket));
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			validator.validate();
+		}).getMessage();
+
+		assertEquals("The bucket antoherBucket has the inventoryEnabled but no inventoryBucket was defined.", errorMessage);
+	}
+	
+	@Test
+	public void testValidateWithInventoryDefinedAndNoBucket() {
+		// The inventory bucket is defined, but it's not defined in the list of buckets
+		String inventoryBucketName = "inventory";
+
+		S3BucketDescriptor anotherBucket = new S3BucketDescriptor();
+		anotherBucket.setName("antoherBucket");
+		anotherBucket.setInventoryEnabled(true);
+
+		when(mockConfig.getInventoryBucket()).thenReturn(inventoryBucketName);
+		when(mockConfig.getBuckets()).thenReturn(Arrays.asList(anotherBucket));
+
+		String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+			// Call under test
+			validator.validate();
+		}).getMessage();
+
+		assertEquals("An inventory bucket is defined but was not in the list of buckets.", errorMessage);
+	}
+}


### PR DESCRIPTION
- Refactored the S3 bucket builder to its own main
- Externalized to a config.json
- Added support for enabling the S3 inventory
- Added support for (simple for now) bucket life cycle with number of retention days
- Added JUnit 5 support with backward Junit 4 API compatibility