### PR TITLE
PLFM-6755: Update to beanstalk platform to 3.4.7

### DIFF
--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -68,6 +68,6 @@ org.sagebionetworks.secret.keys.csv=org.sagebionetworks.id.generator.database.pa
 org.sagebionetworks.beanstalk.image.version.java=8
 org.sagebionetworks.beanstalk.image.version.tomcat=8.5
 #use "latest" for latest supported version of Amazon Linux or a specific version such as "3.0.6"
-org.sagebionetworks.beanstalk.image.version.amazonlinux=3.4.6
+org.sagebionetworks.beanstalk.image.version.amazonlinux=3.4.7
 # The Synapse OAuth authorization endpoint
 org.sagebionetworks.oauth.authorization.endpoint=https://signin.synapse.org


### PR DESCRIPTION
This upgrades the platform in stackBuilder to avoid being rolled back to 3.4.6 if we had to patch (we have been auto-updated to 3.4.7).