### PR TITLE
PLFM-7254-2: Remove routes from old vpc to new one and remove pcx

### DIFF
--- a/src/main/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImpl.java
@@ -125,10 +125,6 @@ public class VpcTemplateBuilderImpl implements VpcTemplateBuilder {
 				.withParameterValue(config.getProperty(PROPERTY_KEY_VPC_VPN_CIDR));
 		Parameter VpnCidrNew = new Parameter().withParameterKey(PARAMETER_VPN_CIDR_NEW)
 				.withParameterValue(config.getProperty(PROPERTY_KEY_VPC_VPN_CIDR_NEW));
-		Parameter oldVpcId = new Parameter().withParameterKey(PARAMETER_OLD_VPC_ID)
-				.withParameterValue(config.getProperty(PROPERTY_KEY_OLD_VPC_ID));
-		Parameter oldVpcCidr = new Parameter().withParameterKey(PARAMETER_OLD_VPC_CIDR)
-				.withParameterValue(config.getProperty(PROPERTY_KEY_OLD_VPC_CIDR));
-		return new Parameter[] { VpnCidr, VpnCidrNew, oldVpcId, oldVpcCidr };
+		return new Parameter[] { VpnCidr, VpnCidrNew };
 	}
 }

--- a/src/main/resources/templates/vpc/main-vpc.json.vtp
+++ b/src/main/resources/templates/vpc/main-vpc.json.vtp
@@ -11,16 +11,6 @@
 			"Description": "CIDR of the AWS VPN",
 			"Type": "String",
 			"Default": "10.50.0.0/16"
-		},
-		"OldVpcId": {
-		    "Description": "VpcId of old Synapse VPC for this stack",
-		    "Type": "String",
-		    "Default": "vpc-c2d49cb9"
-		},
-		"OldVpcCidr": {
-		    "Description": "CIDR of the old Synapse VPC for this stack",
-		    "Type": "String",
-		    "Default": "10.21.0.0/16"
 		}
 	},
 	"Resources": {
@@ -61,27 +51,6 @@
 				]
 			}
 		},
-        "TempVpcPeeringConnection" :{
-            "Type" : "AWS::EC2::VPCPeeringConnection",
-            "Properties" : {
-                "PeerVpcId" : { "Ref": "OldVpcId" },
-                "VpcId" : {
-                    "Ref": "VPC"
-                },
-                "Tags": [
-                    {
-                        "Key": "Application",
-                        "Value": {
-                            "Ref": "AWS::StackName"
-                        }
-                    },
-                    {
-                        "Key": "Name",
-                        "Value": "synapse-${stack}-tempVPC-peering"
-                    }
-                ]
-            }
-        },
 		"InternetGateway": {
 			"Type": "AWS::EC2::InternetGateway",
 			"Properties": {
@@ -137,31 +106,6 @@
                 }]
             }
         },
-        "TempVpcSecurityGroup": {
-             "DependsOn": "VPC",
-             "Type": "AWS::EC2::SecurityGroup",
-             "Properties": {
-                 "GroupDescription": "Security Group for VPN",
-                 "VpcId": {
-                     "Ref": "VPC"
-                 },
-                 "SecurityGroupIngress": [{
-                     "CidrIp": {
-                         "Ref": "OldVpcCidr"
-                     },
-                     "FromPort": "-1",
-                     "ToPort": "-1",
-                     "IpProtocol": "-1",
-                     "Description": "Allow all traffic from the old VPC"
-                 }],
-                 "SecurityGroupEgress": [{
-                     "CidrIp": "0.0.0.0/0",
-                     "FromPort": "-1",
-                     "ToPort": "-1",
-                     "IpProtocol": "-1"
-                 }]
-             }
-         },
 		"NetworkAcl": {
 			"Type": "AWS::EC2::NetworkAcl",
 			"Properties": {
@@ -418,26 +362,6 @@
 				}
 		    }
 		},
-        "TempVpcPeeringConnection": {
-            "Description": "Temporary VpcPeeringConnection for the ${stack} stack",
-            "Value": { "Ref": "TempVpcPeeringConnection" },
-            "Export": {
-                "Name": {
-                    "Fn::Join": [
-                        "-",
-                        [
-                            {
-                                "Ref": "AWS::Region"
-                            },
-                            {
-                                "Ref": "AWS::StackName"
-                            },
-                            "TempVpcPeeringConnectionId"
-                        ]
-                    ]
-                }
-            }
-        },
 		"NetworkAcl": {
 		    "Description": "Network ACL for the ${stack} stack",
 		    "Value": { "Ref": "NetworkAcl" },

--- a/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
@@ -103,8 +103,6 @@ public class VpcTemplateBuilderImplTest {
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_VPN_CIDR_NEW)).thenReturn(vpnCiderNew);
 		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_PEERING_ACCEPT_ROLE_ARN)).thenReturn(peeringRoleARN);
-		when(mockConfig.getProperty(PROPERTY_KEY_OLD_VPC_ID)).thenReturn(oldVpcId);
-		when(mockConfig.getProperty(PROPERTY_KEY_OLD_VPC_CIDR)).thenReturn(oldVpcCidr);
 
 	}
 	
@@ -159,17 +157,13 @@ public class VpcTemplateBuilderImplTest {
 		// call under test
 		Parameter[] parameters = builder.createParameters(stackName);
 		assertNotNull(parameters);
-		assertEquals(4, parameters.length);
+		assertEquals(2, parameters.length);
 		// keys
 		assertEquals(PARAMETER_VPN_CIDR,parameters[0].getParameterKey());
 		assertEquals(PARAMETER_VPN_CIDR_NEW, parameters[1].getParameterKey());
-		assertEquals(PARAMETER_OLD_VPC_ID, parameters[2].getParameterKey());
-		assertEquals(PARAMETER_OLD_VPC_CIDR, parameters[3].getParameterKey());
 		// values
 		assertEquals(vpnCider, parameters[0].getParameterValue());
 		assertEquals(vpnCiderNew, parameters[1].getParameterValue());
-		assertEquals(oldVpcId, parameters[2].getParameterValue());
-		assertEquals(oldVpcCidr, parameters[3].getParameterValue());
 	}
 	
 	@Test


### PR DESCRIPTION
This PR concludes the removal of the link between the old dev vpc and the new one.