### PR TITLE
IT-1874: Remove routes from subnets to Sophos VPN

### DIFF
--- a/src/main/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImpl.java
@@ -121,10 +121,8 @@ public class VpcTemplateBuilderImpl implements VpcTemplateBuilder {
 	 * @return
 	 */
 	public Parameter[] createParameters(String stackName) {
-		Parameter VpnCidr = new Parameter().withParameterKey(PARAMETER_VPN_CIDR)
-				.withParameterValue(config.getProperty(PROPERTY_KEY_VPC_VPN_CIDR));
 		Parameter VpnCidrNew = new Parameter().withParameterKey(PARAMETER_VPN_CIDR_NEW)
 				.withParameterValue(config.getProperty(PROPERTY_KEY_VPC_VPN_CIDR_NEW));
-		return new Parameter[] { VpnCidr, VpnCidrNew };
+		return new Parameter[] { VpnCidrNew };
 	}
 }

--- a/src/main/resources/templates/vpc/main-vpc.json.vtp
+++ b/src/main/resources/templates/vpc/main-vpc.json.vtp
@@ -2,6 +2,11 @@
 	"AWSTemplateFormatVersion": "2010-09-09",
 	"Description": "Creates a VPC with public and private subnets for the Synapse stacks.",
 	"Parameters": {
+		"VpnCidr": {
+			"Description": "CIDR of the (sophos-utm) VPN",
+			"Type": "String",
+			"Default": "10.1.0.0/16"
+		},
 		"VpnCidrNew": {
 			"Description": "CIDR of the AWS VPN",
 			"Type": "String",
@@ -199,6 +204,28 @@
 								"Ref": "AWS::StackName"
 							},
 							"VpcCidr"
+						]
+					]
+				}
+			}
+		},
+		"VpnCidr": {
+			"Description": "VPN CIDR used to create this VPC",
+			"Value": {
+				"Ref": "VpnCidr"
+			},
+			"Export": {
+				"Name": {
+					"Fn::Join": [
+						"-",
+						[
+							{
+								"Ref": "AWS::Region"
+							},
+							{
+								"Ref": "AWS::StackName"
+							},
+							"VpnCidr"
 						]
 					]
 				}

--- a/src/main/resources/templates/vpc/main-vpc.json.vtp
+++ b/src/main/resources/templates/vpc/main-vpc.json.vtp
@@ -2,11 +2,6 @@
 	"AWSTemplateFormatVersion": "2010-09-09",
 	"Description": "Creates a VPC with public and private subnets for the Synapse stacks.",
 	"Parameters": {
-		"VpnCidr": {
-			"Description": "CIDR of the (sophos-utm) VPN",
-			"Type": "String",
-			"Default": "10.1.0.0/16"
-		},
 		"VpnCidrNew": {
 			"Description": "CIDR of the AWS VPN",
 			"Type": "String",
@@ -204,28 +199,6 @@
 								"Ref": "AWS::StackName"
 							},
 							"VpcCidr"
-						]
-					]
-				}
-			}
-		},
-		"VpnCidr": {
-			"Description": "VPN CIDR used to create this VPC",
-			"Value": {
-				"Ref": "VpnCidr"
-			},
-			"Export": {
-				"Name": {
-					"Fn::Join": [
-						"-",
-						[
-							{
-								"Ref": "AWS::Region"
-							},
-							{
-								"Ref": "AWS::StackName"
-							},
-							"VpnCidr"
 						]
 					]
 				}

--- a/src/main/resources/templates/vpc/private-subnet-resources.json.vtp
+++ b/src/main/resources/templates/vpc/private-subnet-resources.json.vtp
@@ -71,29 +71,6 @@
                 ]
             }
         },
-        "${privateSubnet.name}RouteVPN": {
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "${privateSubnet.name}RouteTable"
-                },
-                "DestinationCidrBlock": "10.1.0.0/16",
-                "VpcPeeringConnectionId": {
-                    "Fn::ImportValue": {
-                        "Fn::Join": [
-                          "-",
-                          [
-                              {
-                                  "Ref": "AWS::Region"
-                              },
-                              "${vpcStackName}",
-                              "VpcPeeringConnectionId"
-                          ]
-                        ]
-                    }
-                }
-            }
-        },
         "${privateSubnet.name}PrivateRoute": {
             "Type": "AWS::EC2::Route",
             "Properties": {

--- a/src/main/resources/templates/vpc/public-subnets-resources.json.vtp
+++ b/src/main/resources/templates/vpc/public-subnets-resources.json.vtp
@@ -68,29 +68,6 @@
                 ]
             }
         },
-        "${publicSubnet.name}RouteVPN": {
-            "Type": "AWS::EC2::Route",
-            "Properties": {
-                "RouteTableId": {
-                    "Ref": "${publicSubnet.name}RouteTable"
-                },
-                "DestinationCidrBlock": "10.1.0.0/16",
-                "VpcPeeringConnectionId": {
-                    "Fn::ImportValue": {
-                        "Fn::Join": [
-                            "-",
-                            [
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                "${vpcStackName}",
-                                "VpcPeeringConnectionId"
-                            ]
-                        ]
-                    }
-                }
-            }
-        },
         "${publicSubnet.name}PublicRoute": {
             "Type": "AWS::EC2::Route",
             "Properties": {

--- a/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
@@ -157,13 +157,11 @@ public class VpcTemplateBuilderImplTest {
 		// call under test
 		Parameter[] parameters = builder.createParameters(stackName);
 		assertNotNull(parameters);
-		assertEquals(2, parameters.length);
+		assertEquals(1, parameters.length);
 		// keys
-		assertEquals(PARAMETER_VPN_CIDR,parameters[0].getParameterKey());
-		assertEquals(PARAMETER_VPN_CIDR_NEW, parameters[1].getParameterKey());
+		assertEquals(PARAMETER_VPN_CIDR_NEW, parameters[0].getParameterKey());
 		// values
-		assertEquals(vpnCider, parameters[0].getParameterValue());
-		assertEquals(vpnCiderNew, parameters[1].getParameterValue());
+		assertEquals(vpnCiderNew, parameters[0].getParameterValue());
 	}
 	
 	@Test


### PR DESCRIPTION
This PR removes the routes to 10.1.0.0/16 from the subnets. This clears the way for removing the peering connection (has to be done in two steps because the peering itself is in the shared part which gets executed before the subnets part). Also left the VpnCidr export because it's used by idgen and shared-resources.