### PR TITLE
IT-1874: Remove pcx from synapseprod to admincentral

### DIFF
--- a/src/main/resources/templates/vpc/main-vpc.json.vtp
+++ b/src/main/resources/templates/vpc/main-vpc.json.vtp
@@ -28,29 +28,6 @@
 				]
 			}
 		},
-		"VpcPeeringConnection" :{
-			"Type" : "AWS::EC2::VPCPeeringConnection",
-			"Properties" : {
-				"PeerVpcId" : "vpc-2135cc5a",
-				"PeerOwnerId" : "745159704268",
-				"PeerRoleArn" : "${peerRoleArn}",
-				"VpcId" : {
-					"Ref": "VPC"
-				},
-				"Tags": [
-					{
-						"Key": "Application",
-						"Value": {
-							"Ref": "AWS::StackName"
-						}
-					},
-					{
-						"Key": "Name",
-						"Value": "synapse-${stack}-VPC-peering"
-					}
-				]
-			}
-		},
 		"InternetGateway": {
 			"Type": "AWS::EC2::InternetGateway",
 			"Properties": {
@@ -341,26 +318,6 @@
 					]
 				}
 			}
-		},
-		"VpcPeeringConnection": {
-		    "Description": "VpcPeeringConnection for the ${stack} stack",
-		    "Value": { "Ref": "VpcPeeringConnection" },
-		    "Export": {
-				"Name": {
-					"Fn::Join": [
-						"-",
-						[
-							{
-								"Ref": "AWS::Region"
-							},
-							{
-								"Ref": "AWS::StackName"
-							},
-							"VpcPeeringConnectionId"
-						]
-					]
-				}
-		    }
 		},
 		"NetworkAcl": {
 		    "Description": "Network ACL for the ${stack} stack",

--- a/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/vpc/VpcTemplateBuilderImplTest.java
@@ -99,7 +99,6 @@ public class VpcTemplateBuilderImplTest {
 		oldVpcId = "vpc-123def";
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_SUBNET_PREFIX)).thenReturn(subnetPrefix);
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_AVAILABILITY_ZONES)).thenReturn("us-east-1a,us-east-1b");
-		when(mockConfig.getProperty(PROPERTY_KEY_VPC_VPN_CIDR)).thenReturn(vpnCider);
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_VPN_CIDR_NEW)).thenReturn(vpnCiderNew);
 		when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
 		when(mockConfig.getProperty(PROPERTY_KEY_VPC_PEERING_ACCEPT_ROLE_ARN)).thenReturn(peeringRoleARN);
@@ -130,7 +129,6 @@ public class VpcTemplateBuilderImplTest {
 		JSONObject resouces = templateJson.getJSONObject("Resources");
 		assertNotNull(resouces);
 		assertTrue(resouces.has("VPC"));
-		assertTrue(resouces.has("VpcPeeringConnection"));
 		assertTrue(resouces.has("InternetGateway"));
 		assertTrue(resouces.has("InternetGatewayAttachment"));
 		assertTrue(resouces.has("VpnSecurityGroup"));
@@ -149,6 +147,19 @@ public class VpcTemplateBuilderImplTest {
 		assertFalse(resouces.has("GreenPrivateUsEast1b"));
 		assertFalse(resouces.has("GreenPrivateUsEast1aRouteTableAssociation"));
 		assertFalse(resouces.has("GreenPrivateUsEast1bRouteTableAssociation"));
+
+		JSONObject outputs = templateJson.getJSONObject("Outputs");
+		assertNotNull(outputs);
+		assertTrue(outputs.has("VPCId"));
+		assertTrue(outputs.has("VpcCidr"));
+		assertTrue(outputs.has("VpnCidr"));
+		assertTrue(outputs.has("VpnCidrNew"));
+		assertTrue(outputs.has("VpcGatewayAttachment"));
+		assertTrue(outputs.has("VpcDefaultSecurityGroup"));
+		assertTrue(outputs.has("VpnSecurityGroup"));
+		assertTrue(outputs.has("AvailabilityZones"));
+		assertTrue(outputs.has("NetworkAcl"));
+		assertTrue(outputs.has("InternetGateway"));
 	}
 	
 	@Test


### PR DESCRIPTION
This PR removes the peering connection. This should be the last peering connection in admincentral.