### PR TITLE
PLFM-7504: Disable IMDSv1 (securityHub)

### DIFF
--- a/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
+++ b/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
@@ -92,6 +92,11 @@
 						}
 					},
 					{
+					    "Namespace": "aws:autoscaling:launchconfiguration",
+					    "OptionName": "DisableIMDSv1",
+                         "Value": "true"
+					},
+					{
 						"Namespace": "aws:autoscaling:trigger",
 						"OptionName": "BreachDuration",
 						"Value": "10"


### PR DESCRIPTION
This PR disables IDMSv1 to satisfy control AutoScaling.3 raised by SecurityHub.
Background info: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
