### PR TITLE
Release 471

### DIFF
--- a/src/main/resources/templates/repo/ebextensions/alb-dependencies.json
+++ b/src/main/resources/templates/repo/ebextensions/alb-dependencies.json
@@ -1,5 +1,4 @@
 {
-	"AWSTemplateFormatVersion": "2010-09-09",
 	"Description": "Application Load balancer dependencies",
 	"Resources": {
 		"webACLAssociation": {


### PR DESCRIPTION
This m PR merges the removal of the version in alb-dependencies.json (deployed on 471) back in develop.