### PR TITLE
PLFM-8057: Remove invalid key

### DIFF
--- a/src/main/resources/templates/repo/ebextensions/alb-dependencies.json
+++ b/src/main/resources/templates/repo/ebextensions/alb-dependencies.json
@@ -1,5 +1,4 @@
 {
-	"Description": "Application Load balancer dependencies",
 	"Resources": {
 		"webACLAssociation": {
 			"Type": "AWS::WAFv2::WebACLAssociation",


### PR DESCRIPTION
This PR just removes an attribute that shows up as error in Beanstalk logs.