### PR TITLE
[IT-1360] Redirect legacy user-guides URL

### DIFF
--- a/src/main/resources/templates/dns/prod_docs_clients_dns.json
+++ b/src/main/resources/templates/dns/prod_docs_clients_dns.json
@@ -103,7 +103,7 @@
       "name" : "user-guides.synapse.org.",
       "type" : "CNAME",
       "ttl" : "300",
-      "resourceRecords" : [ "sage-bionetworks.github.io" ],
+      "resourceRecords" : [ "help.synapse.org" ],
       "aliasTargetDescriptor" : null
     }
   ]


### PR DESCRIPTION
The Github Pages CNAME for user-guides.synapse.org has been removed, redirect the url to help.synapse.org so that cached search engine results will link to current documentation.