### PR TITLE
[IT-1360] Remove legacy user-guides URL

### DIFF
--- a/src/main/resources/templates/dns/prod_docs_clients_dns.json
+++ b/src/main/resources/templates/dns/prod_docs_clients_dns.json
@@ -99,12 +99,6 @@
         "hostedZoneId" : "Z3AQBSTGFYJSTF",
         "dnsName" : "s3-website-us-east-1.amazonaws.com."
       }
-    }, {
-      "name" : "user-guides.synapse.org.",
-      "type" : "CNAME",
-      "ttl" : "300",
-      "resourceRecords" : [ "sage-bionetworks.github.io" ],
-      "aliasTargetDescriptor" : null
     }
   ]
 }


### PR DESCRIPTION
The Github Pages CNAME for user-guides.synapse.org has been removed from Github, also remove this CNAME.