### PR TITLE
PLFM-8848 - reverting previous change to instance tag

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -155,7 +155,7 @@ public class Constants {
 
 	public static final String TAG_VALUE_PROJECT = "Synapse";
 	public static final String TAG_VALUE_OWNER_EMAIL = "platform@sagebase.org";
-	public static final String TAG_VALUE_STACK_ARMOR = "install-stack-armor-agent";
+	public static final String TAG_VALUE_STACK_ARMOR = "install-stack-armor-agent-AL2023";
 	// tag keys
 	public static final String TAG_KEY_DEPARTMENT = "Department";
 	public static final String TAG_KEY_PROJECT = "Project";

--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -155,7 +155,7 @@ public class Constants {
 
 	public static final String TAG_VALUE_PROJECT = "Synapse";
 	public static final String TAG_VALUE_OWNER_EMAIL = "platform@sagebase.org";
-	public static final String TAG_VALUE_STACK_ARMOR = "install-stack-armor-agent-AL2023";
+	public static final String TAG_VALUE_STACK_ARMOR = "install-stack-armor-agent";
 	// tag keys
 	public static final String TAG_KEY_DEPARTMENT = "Department";
 	public static final String TAG_KEY_PROJECT = "Project";


### PR DESCRIPTION
I was sure that the Nessus agent installation was different for AL2023 vs. AL2 but Stack Armor today said:
> The existing script should work for either.
So let's revert the last change.