### PR TITLE
SAGL-89: support distinct webACL for each stack instance (prod, staging, tst)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
 		<!--junit4 engine for backwards compatibility -->
 		<dependency>
 			<groupId>org.junit.vintage</groupId>

--- a/src/main/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImpl.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.cloudformation.model.Stack;
 import java.io.StringWriter;
 import java.util.Optional;
 
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_INSTANCE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 
 public class CdnWebAclBuilderImpl implements CdnWebAclBuilder {
@@ -41,8 +42,11 @@ public class CdnWebAclBuilderImpl implements CdnWebAclBuilder {
     }
 
     Optional<Stack> buildCdnWebAcl() {
-
-        String cfStackName = String.format("%s-cloudfront-webacl-stack", config.getProperty(PROPERTY_KEY_STACK));
+        // use instance to really pass a pseudo-instance (prod | staging | tst)
+        // so we can have separate webACLs to test in the prod stack (dev stack does not use CDN)
+        String instance = config.getProperty(PROPERTY_KEY_INSTANCE);
+        validateInstance(instance);
+        String cfStackName = String.format("%s-%s-cloudfront-webacl-stack", config.getProperty(PROPERTY_KEY_STACK), instance);
         Template cfTemplate = velocityEngine.getTemplate(TEMPLATE_WAF_CDN);
         VelocityContext context = new VelocityContext();
         StringWriter writer = new StringWriter();
@@ -62,5 +66,18 @@ public class CdnWebAclBuilderImpl implements CdnWebAclBuilder {
             throw new RuntimeException("Stack creation/update was interrupted", e);
         }
         return cloudFormationClientWrapper.describeStack(cfStackName);
+    }
+
+    /**
+     *
+     * @param instance
+     * @return true if instance in (prod, staging, tst)
+     * @raise IllegalArgumentException if not
+     */
+    private void validateInstance(String instance) {
+        if ("prod".equals(instance) || "staging".equals(instance) || "tst".equals(instance)) {
+            return;
+        }
+        throw new IllegalArgumentException("Invalid instance: " + instance);
     }
 }

--- a/src/main/resources/templates/cdn/synapse-cdn-webacl.json.vtp
+++ b/src/main/resources/templates/cdn/synapse-cdn-webacl.json.vtp
@@ -1,8 +1,8 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "WebACL for CloudFront distributions",
+  "Description": "WebACL for CloudFront distribution",
   "Resources": {
-    "SharedCloudFrontWebACL": {
+    "CloudFrontWebACL": {
       "Type": "AWS::WAFv2::WebACL",
       "Properties": {
         "Scope": "CLOUDFRONT",
@@ -12,14 +12,14 @@
         "VisibilityConfig": {
           "SampledRequestsEnabled": true,
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "SharedCloudFrontWebACL"
+          "MetricName": "CloudFrontWebACL"
         },
         "Rules": [
           {
             "Name": "AWSManagedRulesCommonRuleSet",
             "Priority": 1,
             "OverrideAction": {
-              "None": {}
+              "Count": {}
             },
             "Statement": {
               "ManagedRuleGroupStatement": {
@@ -41,7 +41,7 @@
     "WebACLArn": {
       "Description": "ARN of the shared WAF WebACL",
       "Value": {
-        "Fn::GetAtt": ["SharedCloudFrontWebACL", "Arn"]
+        "Fn::GetAtt": ["CloudFrontWebACL", "Arn"]
       },
       "Export": {
         "Name": { "Fn::Sub": "#[[${AWS::AccountId}-${AWS::StackName}]]#-WebACLArn" }

--- a/src/main/resources/templates/cdn/synapse-cdn-webacl.json.vtp
+++ b/src/main/resources/templates/cdn/synapse-cdn-webacl.json.vtp
@@ -39,7 +39,7 @@
   },
   "Outputs": {
     "WebACLArn": {
-      "Description": "ARN of the shared WAF WebACL",
+      "Description": "ARN of the WAF WebACL",
       "Value": {
         "Fn::GetAtt": ["CloudFrontWebACL", "Arn"]
       },

--- a/src/test/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImplTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.mockito.ArgumentCaptor;
@@ -72,18 +73,19 @@ public class CdnWebAclBuilderImplTest {
         List<Tag> expectedTags = new ArrayList<>();
         Tag tag = Tag.builder().key("aKey").value("aValue").build();
         expectedTags.add(tag);
-        Stack expectedStack = Stack.builder().stackName("tst-cloudfront-webacl-stack").tags(expectedTags).build();
+        Stack expectedStack = Stack.builder().stackName("dev-staging-cloudfront-webacl-stack").tags(expectedTags).build();
         when(mockStackTagsProvider.getStackTags(mockConfig)).thenReturn(expectedTags);
         when(mockCloudFormationClientWrapper.waitForStackToComplete(any(String.class))).thenReturn(Optional.of(expectedStack));
         when(mockCloudFormationClientWrapper.describeStack(any(String.class))).thenReturn(Optional.of(expectedStack));
 
-        when(mockConfig.getProperty("org.sagebionetworks.stack")).thenReturn("tst");
+        when(mockConfig.getProperty("org.sagebionetworks.stack")).thenReturn("dev");
+        when(mockConfig.getProperty("org.sagebionetworks.instance")).thenReturn("staging");
 
         // call under test
         Optional<Stack> optStack = builder.buildCdnWebAcl();
 
         assertTrue(optStack.isPresent());
-        assertEquals("tst-cloudfront-webacl-stack", optStack.get().stackName());
+        assertEquals("dev-staging-cloudfront-webacl-stack", optStack.get().stackName());
         assertEquals(1, optStack.get().tags().size());
         assertEquals(tag, optStack.get().tags().get(0));
 
@@ -91,14 +93,27 @@ public class CdnWebAclBuilderImplTest {
         verify(mockCloudFormationClientWrapper).createOrUpdateStack(createOrUpdateStackRequestArgumentCaptor.capture());
         CreateOrUpdateStackRequest actualReq = createOrUpdateStackRequestArgumentCaptor.getValue();
         assertNotNull(actualReq);
-        assertEquals("tst-cloudfront-webacl-stack", actualReq.getStackName());
+        assertEquals("dev-staging-cloudfront-webacl-stack", actualReq.getStackName());
         assertEquals("someYamlTemplate", actualReq.getTemplateBody());
         assertEquals(tag, actualReq.getTags().get(0));
 
         assertTrue(optStack.isPresent());
-        assertEquals("tst-cloudfront-webacl-stack", optStack.get().stackName());
+        assertEquals("dev-staging-cloudfront-webacl-stack", optStack.get().stackName());
         assertEquals(1, optStack.get().tags().size());
         assertEquals(tag, optStack.get().tags().get(0));
+
+    }
+
+    @Test
+    public void testBuildCdnWebAclStackWithInvalidInstance() throws Exception {
+
+        when(mockConfig.getProperty("org.sagebionetworks.instance")).thenReturn("badinstance");
+
+        // call under test
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            builder.buildCdnWebAcl();
+        });
+        assertEquals("Invalid instance: badinstance", e.getMessage());
 
     }
 

--- a/src/test/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/cdn/webacl/CdnWebAclBuilderImplTest.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -58,8 +60,9 @@ public class CdnWebAclBuilderImplTest {
     @InjectMocks
     private CdnWebAclBuilderImpl builder;
 
-    @Test
-    public void testBuildCdnWebAclStack() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"prod", "staging", "tst"})
+    public void testBuildCdnWebAclStack(String instance) throws Exception {
         when(mockVelocityEngine.getTemplate(any(String.class))).thenReturn(mockTemplate);
         doAnswer(new Answer<Void>() {
             @Override
@@ -73,19 +76,20 @@ public class CdnWebAclBuilderImplTest {
         List<Tag> expectedTags = new ArrayList<>();
         Tag tag = Tag.builder().key("aKey").value("aValue").build();
         expectedTags.add(tag);
-        Stack expectedStack = Stack.builder().stackName("dev-staging-cloudfront-webacl-stack").tags(expectedTags).build();
+        String expectedStackName = "dev-" + instance + "-cloudfront-webacl-stack";
+        Stack expectedStack = Stack.builder().stackName(expectedStackName).tags(expectedTags).build();
         when(mockStackTagsProvider.getStackTags(mockConfig)).thenReturn(expectedTags);
         when(mockCloudFormationClientWrapper.waitForStackToComplete(any(String.class))).thenReturn(Optional.of(expectedStack));
         when(mockCloudFormationClientWrapper.describeStack(any(String.class))).thenReturn(Optional.of(expectedStack));
 
         when(mockConfig.getProperty("org.sagebionetworks.stack")).thenReturn("dev");
-        when(mockConfig.getProperty("org.sagebionetworks.instance")).thenReturn("staging");
+        when(mockConfig.getProperty("org.sagebionetworks.instance")).thenReturn(instance);
 
         // call under test
         Optional<Stack> optStack = builder.buildCdnWebAcl();
 
         assertTrue(optStack.isPresent());
-        assertEquals("dev-staging-cloudfront-webacl-stack", optStack.get().stackName());
+        assertEquals(expectedStackName, optStack.get().stackName());
         assertEquals(1, optStack.get().tags().size());
         assertEquals(tag, optStack.get().tags().get(0));
 
@@ -93,14 +97,9 @@ public class CdnWebAclBuilderImplTest {
         verify(mockCloudFormationClientWrapper).createOrUpdateStack(createOrUpdateStackRequestArgumentCaptor.capture());
         CreateOrUpdateStackRequest actualReq = createOrUpdateStackRequestArgumentCaptor.getValue();
         assertNotNull(actualReq);
-        assertEquals("dev-staging-cloudfront-webacl-stack", actualReq.getStackName());
+        assertEquals(expectedStackName, actualReq.getStackName());
         assertEquals("someYamlTemplate", actualReq.getTemplateBody());
         assertEquals(tag, actualReq.getTags().get(0));
-
-        assertTrue(optStack.isPresent());
-        assertEquals("dev-staging-cloudfront-webacl-stack", optStack.get().stackName());
-        assertEquals(1, optStack.get().tags().size());
-        assertEquals(tag, optStack.get().tags().get(0));
 
     }
 


### PR DESCRIPTION
The dev stack does not use CDN so the idea of testing in dev and sharing a single webACL for all the prod stack instances does not work. This PR adds support for separate webACL for the stack instances 'prod', 'staging' and 'tst'. We'll have each CDN reference their respective webACL and we'll be able to test on the staging or tst instances.
Also changed the action to count in the webACL.