### PR TITLE
PLFM-9092: remove reference to non-existent role

### DIFF
--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -741,8 +741,7 @@
                                     #if(${stack} == 'prod')
                                     { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_6620166dd0e7f1b6" }
                                     #else
-                                    { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_693a85eb20cd5043" },
-                                    { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Synapse-Build-${instance}-CodeBuildServiceRole" }
+                                    "*"
                                     #end
 								]
 							},

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -734,16 +734,7 @@
 							"Sid": "Allow root administration of the key",
 							"Effect": "Allow",
 							"Principal": {
-								"AWS": [
-								    { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:root" },
-                                    { "Fn::ImportValue": "us-east-1-synapse-${stack}-cmk-SynapseDeploymentRoleArn"},
-                                    { "Fn::GetAtt": [ "${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] },
-                                    #if(${stack} == 'prod')
-                                    { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_6620166dd0e7f1b6" }
-                                    #else
-                                    "*"
-                                    #end
-								]
+								"AWS":  "*"
 							},
 							"Action": [
 								"kms:*"


### PR DESCRIPTION
The 'deny' statement does the job of filtering the roles so it's OK to use '*' in the 'allow' statement.