### PR TITLE
SAGL-89: Simplified docs redirector

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -105,6 +105,7 @@ public class Constants {
 	public static final String PROPERTY_KEY_BEANSTALK_VERSION = "org.sagebionetworks.beanstalk.version.";
 	public static final String PROPERTY_KEY_BEANSTALK_NUMBER = "org.sagebionetworks.beanstalk.number.";
 	public static final String PROPERTY_KEY_BEANSTALK_SSL_ARN = "org.sagebionetworks.beanstalk.ssl.arn.";
+	public static final String PROPERTY_KEY_DOCS_SSL_ARN = "org.sagebionetworks.docs.ssl.arn";
 	public static final String PROPERTY_KEY_ROUTE_53_HOSTED_ZONE = "org.sagebionetworks.route.53.hosted.zone.";
 	public static final String PROPERTY_KEY_SECRET_KEYS_CSV = "org.sagebionetworks.secret.keys.csv";
 	public static final String PROPERTY_KEY_REPOSITORY_DATABASE_PASSWORD = "org.sagebionetworks.repository.database.password";

--- a/src/main/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImpl.java
@@ -19,6 +19,7 @@ import static org.sagebionetworks.template.Constants.CTXT_KEY_ACM_CERT_ARN;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DOMAIN_NAME;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_SUBDOMAIN_NAME;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_SSL_ARN;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DOCS_SSL_ARN;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK_INSTANCE_ALIAS;
 
 public class UserDocsRedirectorBuilderImpl implements  UserDocsRedirectorBuilder {
@@ -49,7 +50,7 @@ public class UserDocsRedirectorBuilderImpl implements  UserDocsRedirectorBuilder
 	VelocityContext createContext() {
 		VelocityContext ctxt = new VelocityContext();
 		// The ACM ARN is the same as the one used for portal
-		String acmCertificateArn = config.getProperty(PROPERTY_KEY_BEANSTALK_SSL_ARN+"portal");
+		String acmCertificateArn = config.getProperty(PROPERTY_KEY_DOCS_SSL_ARN);
 		ctxt.put(CTXT_KEY_ACM_CERT_ARN, acmCertificateArn);
 		String stackInstanceAlias = config.getProperty(PROPERTY_KEY_STACK_INSTANCE_ALIAS);
 		ctxt.put(CTXT_KEY_SUBDOMAIN_NAME, stackInstanceAlias);

--- a/src/main/resources/templates/redirectors/user_docs_redirector.yaml.vtp
+++ b/src/main/resources/templates/redirectors/user_docs_redirector.yaml.vtp
@@ -6,53 +6,19 @@ Conditions:
   IsProd: !Equals [${SubDomainName}, 'prod']
   IsStaging: !Equals [${SubDomainName}, 'staging']
 Resources:
-  CloudFrontOAI:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-    Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: 'CloudFront OAI for ${SubDomainName}.${DomainName}'
-  WebsiteBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: '${SubDomainName}.${DomainName}'
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      OwnershipControls:
-        Rules:
-          - ObjectOwnership: BucketOwnerEnforced
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-  WebsiteBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      PolicyDocument:
-        Id: BucketPolicy
-        Version: 2012-10-17
-        Statement:
-          - Sid: CFOAIReadForGetBucketObjects
-            Effect: Allow
-            Principal:
-              CanonicalUser: !GetAtt CloudFrontOAI.S3CanonicalUserId
-            Action: 's3:GetObject'
-            Resource: !Join ['', ['arn:aws:s3:::', !Ref WebsiteBucket, '/*']]
-      Bucket: !Ref WebsiteBucket
   Cloudfront:
     Type: AWS::CloudFront::Distribution
-    DependsOn: WebsiteBucket
     Properties:
       DistributionConfig:
         Comment: Cloudfront Distribution pointing to S3 bucket
         Origins:
-          - DomainName: '${SubDomainName}.${DomainName}.s3.amazonaws.com'
-            Id: S3Origin
-            S3OriginConfig:
-              OriginAccessIdentity:
-                !Join [ "", [ "origin-access-identity/cloudfront/", !Ref CloudFrontOAI ] ]
+          - DomainName: dummy.org
+            Id: Dummy
+            CustomOriginConfig:
+                OriginProtocolPolicy: https-only
+                HTTPSPort: 443
+                OriginSSLProtocols:
+                    - TLSv1.2
         Enabled: true
         HttpVersion: 'http2'
         DefaultRootObject: index.html
@@ -65,7 +31,7 @@ Resources:
             - GET
             - HEAD
           Compress: true
-          TargetOriginId: S3Origin
+          TargetOriginId: Dummy
           ForwardedValues:
             QueryString: true
             Cookies:
@@ -113,8 +79,3 @@ Outputs:
     Description: URL for cloudfront
     Export:
       Name: !Join ['-', [!Ref AWS::Region, !Ref AWS::StackName, 'CloudfrontEndpoint']]
-  WebsiteBucket:
-    Value: !Ref WebsiteBucket
-    Description: The bucket containing the website content
-    Export:
-      Name: !Join ['-', [!Ref AWS::Region, !Ref AWS::StackName, 'WebsiteBucket']]

--- a/src/test/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImplTemplateTest.java
+++ b/src/test/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImplTemplateTest.java
@@ -47,7 +47,7 @@ public class UserDocsRedirectorBuilderImplTemplateTest {
 
 	@BeforeEach
 	void setUp() {
-		when(mockConfig.getProperty("org.sagebionetworks.beanstalk.ssl.arn.portal")).thenReturn("acmarn");
+		when(mockConfig.getProperty("org.sagebionetworks.docs.ssl.arn")).thenReturn("acmarn");
 		when(mockConfig.getProperty("org.sagebionetworks.stack.instance.alias")).thenReturn("tst");
 		velocityEngine = new TemplateGuiceModule().velocityEngineProvider();
 		builder = new UserDocsRedirectorBuilderImpl(mockConfig, mockCloudFormationClientWrapper, mockStackTagsProvider, velocityEngine);

--- a/src/test/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/redirectors/userdocs/UserDocsRedirectorBuilderImplTest.java
@@ -59,7 +59,7 @@ class UserDocsRedirectorBuilderImplTest {
 
 	@BeforeEach
 	void setUp() {
-		when(mockConfig.getProperty("org.sagebionetworks.beanstalk.ssl.arn.portal")).thenReturn("acmarn");
+		when(mockConfig.getProperty("org.sagebionetworks.docs.ssl.arn")).thenReturn("acmarn");
 		when(mockConfig.getProperty("org.sagebionetworks.stack.instance.alias")).thenReturn("tst");
 	}
 
@@ -73,7 +73,7 @@ class UserDocsRedirectorBuilderImplTest {
 		// call under test
 		VelocityContext ctxt = builder.createContext();
 
-		verify(mockConfig).getProperty("org.sagebionetworks.beanstalk.ssl.arn.portal");
+		verify(mockConfig).getProperty("org.sagebionetworks.docs.ssl.arn");
 		verify(mockConfig).getProperty("org.sagebionetworks.stack.instance.alias");
 		assertEquals("acmarn", ctxt.get("AcmCertificateArn"));
 		assertEquals("tst", ctxt.get("SubDomainName"));


### PR DESCRIPTION
These are simple redirectors to the Synapse help so no need to add WAF, I just simplified them by removing the buckets and associated resources.
Tested and deployed staging and prod.

TODO: Add CI jobs on synapse-ops-prod.