### PR TITLE
PLFM-9305: Update prod export name for OSSVpcEndpointId

### DIFF
--- a/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
@@ -93,7 +93,12 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
         context.put(DELETION_POLICY, Constants.isProd(config.getProperty(PROPERTY_KEY_STACK)) ? DeletionPolicy.Retain.name() : DeletionPolicy.Delete.name());
         
         context.put(VPC_EXPORT_PREFIX, Constants.createVpcExportPrefix(stack));
-        context.put(OPS_VPC_EXPORT_PREFIX, "us-east-1-vpc");
+        // PLFM-9305: ops vpc has different name in different accounts
+        if ("dev".equals(stack)) {
+            context.put(OPS_VPC_EXPORT_PREFIX, "us-east-1-vpc");
+        } else {
+            context.put(OPS_VPC_EXPORT_PREFIX, "us-east-1-ops-vpc-v2");
+        }
         context.put(IDENTITY_ARN, stsClient.getCallerIdentity().arn());
         
         return context;

--- a/src/test/resources/global/prod-global-resources.json
+++ b/src/test/resources/global/prod-global-resources.json
@@ -139,7 +139,7 @@
           "[{\"Rules\":[{\"ResourceType\":\"collection\",\"Resource\":[\"collection/prod-synhelp\"]}],\"AllowFromPublic\":false,\"SourceServices\":[\"bedrock.amazonaws.com\"],\"SourceVPCEs\":[\"${stackVpcEndpointId}\",\"${opsVpcEndpointId}\"]}]",
           {
             "stackVpcEndpointId": {"Fn::ImportValue": "us-east-1-synapse-prod-vpc-2-open-search-vpce"},
-            "opsVpcEndpointId": {"Fn::ImportValue": "us-east-1-vpc-OSSVpcEndpointId"}
+            "opsVpcEndpointId": {"Fn::ImportValue": "us-east-1-ops-vpc-v2-OSSVpcEndpointId"}
           }
         ]}
       }


### PR DESCRIPTION
This PR updates the export name for OSSVpcEndpointId for the prod stack (the ops vpc names differ from account to account).