### PR TITLE
PLFM-9395: Update data source URL for SynapseHelpKB

### DIFF
--- a/src/main/resources/templates/global/bedrock-kb-template.json.vpt
+++ b/src/main/resources/templates/global/bedrock-kb-template.json.vpt
@@ -176,7 +176,7 @@
                 "WebConfiguration": {
                     "SourceConfiguration": {
                     	"UrlConfiguration": {
-                    		"SeedUrls": [ { "Url": "https://help.synapse.org" } ]
+                    		"SeedUrls": [ { "Url": "https://docs.synapse.org/synapse-docs" } ]
                     	}
                     }
                 }

--- a/src/test/resources/global/dev-global-resources.json
+++ b/src/test/resources/global/dev-global-resources.json
@@ -217,7 +217,7 @@
         "Description": "The datasource for the synapse help document, the data is crawled from the synapse help website",
         "DataSourceConfiguration": {
           "Type": "WEB",
-          "WebConfiguration": {"SourceConfiguration": {"UrlConfiguration": {"SeedUrls": [{"Url": "https://help.synapse.org"}]}}}
+          "WebConfiguration": {"SourceConfiguration": {"UrlConfiguration": {"SeedUrls": [{"Url": "https://docs.synapse.org/synapse-docs"}]}}}
         }
       }
     },

--- a/src/test/resources/global/prod-global-resources.json
+++ b/src/test/resources/global/prod-global-resources.json
@@ -236,7 +236,7 @@
         "Description": "The datasource for the synapse help document, the data is crawled from the synapse help website",
         "DataSourceConfiguration": {
           "Type": "WEB",
-          "WebConfiguration": {"SourceConfiguration": {"UrlConfiguration": {"SeedUrls": [{"Url": "https://help.synapse.org"}]}}}
+          "WebConfiguration": {"SourceConfiguration": {"UrlConfiguration": {"SeedUrls": [{"Url": "https://docs.synapse.org/synapse-docs"}]}}}
         }
       }
     },


### PR DESCRIPTION
This PR updates the URL used by the crawler for the SynapseHelp knowledge base (the original one had been updated to a redirect and caused a problem).