### PR TITLE
Give codebuild role access to stack key for both dev and prod stacks.

### DIFF
--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -842,12 +842,12 @@
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:root" },
                                         { "Fn::ImportValue": "us-east-1-synapse-${stack}-cmk-SynapseDeploymentRoleArn"},
                                         { "Fn::GetAtt": [ "${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] },
+                                        { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Deployment-Pipeline-CodeBuildServiceRole" },
                                         #if(${stack} == 'prod')
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_6620166dd0e7f1b6" }
                                         #else
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_693a85eb20cd5043" },
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Synapse-Build-${instance}-CodeBuildServiceRole" },
-                                        { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Deployment-Pipeline-CodeBuildServiceRole" }
                                         #end
                                     ]
                                 }
@@ -863,7 +863,14 @@
 								"kms:*"
 							],
 							"Resource": "*"
-						}
+						},
+						{
+                          "Sid": "Enable IAM User Permissions",
+                          "Effect": "Allow",
+                          "Principal": { "AWS": { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root" } },
+                          "Action": "kms:*",
+                          "Resource": "*"
+                        }
 					]
 				}
 			}

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -863,14 +863,7 @@
 								"kms:*"
 							],
 							"Resource": "*"
-						},
-						{
-                          "Sid": "Enable IAM User Permissions",
-                          "Effect": "Allow",
-                          "Principal": { "AWS": { "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root" } },
-                          "Action": "kms:*",
-                          "Resource": "*"
-                        }
+						}
 					]
 				}
 			}


### PR DESCRIPTION
Do not merge, should go on 576.

@brucehoff , while looking at deployment error this morning I noticed that we only give permission on the stack instance key to the CodeBuildService role in the dev stack. Should it not be the case for both dev and prod?

The actual error I ran into was 'The new key policy will not allow you to update the key policy in the future.', I think it may be related if somehow Cloudformation thinks we're creating a key we won't be able to manage (which would be the case if the installing role did not have access, per above).
The explicit allow for root was suggested by GPT (it's already covered by the previous statement).