### PR TITLE
PLFM-9469

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,10 @@
 			<artifactId>cloudformation</artifactId>
 			<version>${amazon.sdk.v2.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>cognitoidentityprovider</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -165,6 +165,11 @@ public class Constants {
 	public static final String TAG_KEY_PROJECT = "Project";
 	public static final String TAG_KEY_OWNER_EMAIL = "OwnerEmail";
 	public static final String TAG_KEY_EXECUTE_SCRIPT = "execute-script";
+	
+	// Note: These are also defined in repo-defaults.properties as secrets to be retrieved
+	// from Secrets Manager
+	public static final String SAGEBIO_COGNITO_APP_CLIENT_ID = "org.sagebionetworks.oauth2.sagebio.client.id";
+	public static final String SAGEBIO_COGNITO_APP_CLIENT_SECRET = "org.sagebionetworks.oauth2.sagebio.client.secret";
 
 	// templates
 	public static final String TEMPLATES_VPC_MAIN_VPC_JSON_VTP = "templates/vpc/main-vpc.json.vtp";

--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -278,6 +278,9 @@ public class Constants {
 
 	public static final String CTXT_ENABLE_ENHANCED_RDS_MONITORING = "EnableRdsEnhancedMonitoring";
 
+	public static final String COGNITO_USER_POOL_CF_OUTPUT_NAME = "CognitoUserPoolId";
+	public static final String COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME = "CognitoUserPoolClientId";
+
 	// The secrets manager ids for the key/secret pair for the admin auth
 	public static final String SECRETS_ADMIN_KEY_ID = "org.sagebionetworks.admin.auth.key";
 	public static final String SECRETS_ADMIN_SECRET_ID = "org.sagebionetworks.admin.auth.secret";

--- a/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
+++ b/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
@@ -125,6 +125,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.bedrockagent.BedrockAgentClient;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.elasticbeanstalk.ElasticBeanstalkClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -393,4 +394,11 @@ public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 		return imageBuilderClientBuilder.build();
 	}
 	
+	@Provides
+	public CognitoIdentityProviderClient provideCognitoIdentityProvider() {
+		CognitoIdentityProviderClient client = CognitoIdentityProviderClient.builder().region(Region.US_EAST_1).build();
+		return client;
+	}
+
+
 }

--- a/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
@@ -1,5 +1,7 @@
 package org.sagebionetworks.template.global;
 
+import static org.sagebionetworks.template.Constants.COGNITO_USER_POOL_CF_OUTPUT_NAME;
+import static org.sagebionetworks.template.Constants.COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME;
 import static org.sagebionetworks.template.Constants.DELETION_POLICY;
 import static org.sagebionetworks.template.Constants.GLOBAL_CFSTACK_OUTPUT_KEY_SES_BOUNCE_TOPIC;
 import static org.sagebionetworks.template.Constants.GLOBAL_CFSTACK_OUTPUT_KEY_SES_COMPLAINT_TOPIC;
@@ -8,10 +10,12 @@ import static org.sagebionetworks.template.Constants.IDENTITY_ARN;
 import static org.sagebionetworks.template.Constants.JSON_INDENT;
 import static org.sagebionetworks.template.Constants.OPS_VPC_EXPORT_PREFIX;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
+import static org.sagebionetworks.template.Constants.SAGEBIO_COGNITO_APP_CLIENT_ID;
+import static org.sagebionetworks.template.Constants.SAGEBIO_COGNITO_APP_CLIENT_SECRET;
 import static org.sagebionetworks.template.Constants.SES_SYNAPSE_DOMAIN;
 import static org.sagebionetworks.template.Constants.STACK;
 import static org.sagebionetworks.template.Constants.TEMPLATE_GLOBAL_RESOURCES;
-import static org.sagebionetworks.template.Constants.*;
+import static org.sagebionetworks.template.Constants.VPC_EXPORT_PREFIX;
 
 import java.io.StringWriter;
 import java.util.List;

--- a/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
@@ -11,7 +11,7 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 import static org.sagebionetworks.template.Constants.SES_SYNAPSE_DOMAIN;
 import static org.sagebionetworks.template.Constants.STACK;
 import static org.sagebionetworks.template.Constants.TEMPLATE_GLOBAL_RESOURCES;
-import static org.sagebionetworks.template.Constants.VPC_EXPORT_PREFIX;
+import static org.sagebionetworks.template.Constants.*;
 
 import java.io.StringWriter;
 import java.util.List;
@@ -115,11 +115,13 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
     	        software.amazon.awssdk.services.cloudformation.model.Output::outputValue
     	));
 
-    	String userPoolId = outputMap.get("CognitoUserPoolId"); // TODO define these as constants
-    	String appClientId = outputMap.get("CognitoUserPoolClientId"); /// TODO
+    	String userPoolId = outputMap.get(COGNITO_USER_POOL_CF_OUTPUT_NAME);
+    	String appClientId = outputMap.get(COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME);
     	
-    	if (StringUtils.isEmpty(userPoolId)) throw new IllegalStateException("Stack output 'userPoolId' is required."); // TODO
-    	if (StringUtils.isEmpty(appClientId)) throw new IllegalStateException("Stack output 'appClientId' is required."); // TODO
+    	if (StringUtils.isEmpty(userPoolId)) 
+    		throw new IllegalStateException("Stack output '"+COGNITO_USER_POOL_CF_OUTPUT_NAME+"' is required.");
+    	if (StringUtils.isEmpty(appClientId)) 
+    		throw new IllegalStateException("Stack output '"+COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME+"' is required.");
     	
     	DescribeUserPoolClientRequest userPoolClientRequest = 
     			DescribeUserPoolClientRequest.builder().userPoolId(userPoolId).clientId(appClientId).build();
@@ -134,9 +136,9 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
     	if (StringUtils.isEmpty(cognitoAppClientId)) throw new IllegalStateException("Cognito app is missing client id.");
     	if (StringUtils.isEmpty(cognitoAppClientSecret)) throw new IllegalStateException("Cognito app is missing client secret.");
 
-    	String idName = stackPrefix + ".bhoff" + "."+ Constants.SAGEBIO_COGNITO_APP_CLIENT_ID; // TODO remove .bhoff
+    	String idName = stackPrefix + ".bhoff" + "."+ SAGEBIO_COGNITO_APP_CLIENT_ID; // TODO remove .bhoff
     	setSecret(idName, cognitoAppClientId);
-    	String secretName = stackPrefix + ".bhoff" + "."+ Constants.SAGEBIO_COGNITO_APP_CLIENT_SECRET; // TODO remove .bhoff
+    	String secretName = stackPrefix + ".bhoff" + "."+ SAGEBIO_COGNITO_APP_CLIENT_SECRET; // TODO remove .bhoff
     	setSecret(secretName, cognitoAppClientSecret);
         
     }
@@ -170,6 +172,9 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
         context.put(VPC_EXPORT_PREFIX, Constants.createVpcExportPrefix(stack));
         context.put(OPS_VPC_EXPORT_PREFIX, config.getProperty(Constants.PROPERTY_KEY_OPS_VPC_EXPORT_PREFIX));
         context.put(IDENTITY_ARN, stsClient.getCallerIdentity().arn());
+        
+        context.put(COGNITO_USER_POOL_CF_OUTPUT_NAME, COGNITO_USER_POOL_CF_OUTPUT_NAME);
+        context.put(COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME, COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME);
         
         return context;
     }

--- a/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
@@ -14,6 +14,10 @@ import static org.sagebionetworks.template.Constants.TEMPLATE_GLOBAL_RESOURCES;
 import static org.sagebionetworks.template.Constants.VPC_EXPORT_PREFIX;
 
 import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -30,7 +34,17 @@ import org.sagebionetworks.template.repo.DeletionPolicy;
 import com.google.inject.Inject;
 
 import software.amazon.awssdk.services.cloudformation.model.Capability;
+import software.amazon.awssdk.services.cloudformation.model.Output;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DescribeUserPoolClientRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DescribeUserPoolClientResponse;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
+import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest;
 import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.utils.StringUtils;
+
 
 public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
 
@@ -40,6 +54,8 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
     private final StackTagsProvider stackTagsProvider;
     private final SesClientWrapper sesClientWrapper;
 	private final StsClient stsClient;
+	private final SecretsManagerClient secretsManager;
+	private final CognitoIdentityProviderClient cognitoIdentityProviderClient;
 
     @Inject
     public GlobalResourcesBuilderImpl(CloudFormationClientWrapper cloudFormationClientWrapper,
@@ -47,13 +63,17 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
                                       Configuration config,
                                       StackTagsProvider stackTagsProvider,
                                       SesClientWrapper sesClientWrapper,
-                                      StsClient stsClient) {
+                                      StsClient stsClient,
+                                      SecretsManagerClient secretsManager,
+                                      CognitoIdentityProviderClient cognitoIdentityProviderClient) {
         this.cloudFormationClientWrapper = cloudFormationClientWrapper;
         this.velocityEngine = velocityEngine;
         this.config = config;
         this.stackTagsProvider = stackTagsProvider;
         this.sesClientWrapper = sesClientWrapper;
         this.stsClient = stsClient;
+		this.secretsManager = secretsManager;
+		this.cognitoIdentityProviderClient = cognitoIdentityProviderClient;
     }
 
     @Override
@@ -73,11 +93,66 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
             .withCapabilities(Capability.CAPABILITY_NAMED_IAM)
             .withTags(stackTagsProvider.getStackTags(config))
         );
-        cloudFormationClientWrapper.waitForStackToComplete(stackName);
+        Optional<Stack> stack = cloudFormationClientWrapper.waitForStackToComplete(stackName);
+        
+        // CloudFormation can't get the Cognito application credentials and put them into
+        // Secrets Manager, so we do that as a post-processing step using the AWS client directly
+        copyCognitoSecretsToSecretsManager(config.getProperty(PROPERTY_KEY_STACK), stack.get());
+        
         // setup SES notifications on prod stack
         if ("prod".equalsIgnoreCase(config.getProperty(PROPERTY_KEY_STACK))) {
             setupSesTopics(stackName);
         }
+    }
+    
+    void copyCognitoSecretsToSecretsManager(String stackPrefix, Stack cfStack) {
+    	List<Output> outputs = cfStack.outputs();
+
+    	// Convert outputs to a Map<String, String> for convenience:
+    	Map<String, String> outputMap = outputs.stream()
+    	    .collect(Collectors.toMap(
+    	        software.amazon.awssdk.services.cloudformation.model.Output::outputKey,
+    	        software.amazon.awssdk.services.cloudformation.model.Output::outputValue
+    	));
+
+    	String userPoolId = outputMap.get("CognitoUserPoolId"); // TODO define these as constants
+    	String appClientId = outputMap.get("CognitoUserPoolClientId"); /// TODO
+    	
+    	if (StringUtils.isEmpty(userPoolId)) throw new IllegalStateException("Stack output 'userPoolId' is required."); // TODO
+    	if (StringUtils.isEmpty(appClientId)) throw new IllegalStateException("Stack output 'appClientId' is required."); // TODO
+    	
+    	DescribeUserPoolClientRequest userPoolClientRequest = 
+    			DescribeUserPoolClientRequest.builder().userPoolId(userPoolId).clientId(appClientId).build();
+    	
+    	// Describe the user pool client to get the client id and secret
+    	DescribeUserPoolClientResponse userPoolClientResponse = 
+    			cognitoIdentityProviderClient.describeUserPoolClient(userPoolClientRequest);
+
+    	String cognitoAppClientId = userPoolClientResponse.userPoolClient().clientId();
+    	String cognitoAppClientSecret = userPoolClientResponse.userPoolClient().clientSecret();
+
+    	if (StringUtils.isEmpty(cognitoAppClientId)) throw new IllegalStateException("Cognito app is missing client id.");
+    	if (StringUtils.isEmpty(cognitoAppClientSecret)) throw new IllegalStateException("Cognito app is missing client secret.");
+
+    	String idName = stackPrefix + ".bhoff" + "."+ Constants.SAGEBIO_COGNITO_APP_CLIENT_ID; // TODO remove .bhoff
+    	setSecret(idName, cognitoAppClientId);
+    	String secretName = stackPrefix + ".bhoff" + "."+ Constants.SAGEBIO_COGNITO_APP_CLIENT_SECRET; // TODO remove .bhoff
+    	setSecret(secretName, cognitoAppClientSecret);
+        
+    }
+    
+    void setSecret(String key, String value) {
+    	try {
+    		secretsManager.createSecret(CreateSecretRequest.builder()
+    				.name(key)
+    				.secretString(value)
+    				.build());
+    	} catch (software.amazon.awssdk.services.secretsmanager.model.ResourceExistsException e) {
+    		secretsManager.putSecretValue(PutSecretValueRequest.builder()
+    				.secretId(key)
+    				.secretString(value)
+    				.build());
+    	}
     }
 
     public String createStackName() {

--- a/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImpl.java
@@ -136,9 +136,9 @@ public class GlobalResourcesBuilderImpl implements GlobalResourcesBuilder {
     	if (StringUtils.isEmpty(cognitoAppClientId)) throw new IllegalStateException("Cognito app is missing client id.");
     	if (StringUtils.isEmpty(cognitoAppClientSecret)) throw new IllegalStateException("Cognito app is missing client secret.");
 
-    	String idName = stackPrefix + ".bhoff" + "."+ SAGEBIO_COGNITO_APP_CLIENT_ID; // TODO remove .bhoff
+    	String idName = stackPrefix + "."+ SAGEBIO_COGNITO_APP_CLIENT_ID;
     	setSecret(idName, cognitoAppClientId);
-    	String secretName = stackPrefix + ".bhoff" + "."+ SAGEBIO_COGNITO_APP_CLIENT_SECRET; // TODO remove .bhoff
+    	String secretName = stackPrefix + "."+ SAGEBIO_COGNITO_APP_CLIENT_SECRET;
     	setSecret(secretName, cognitoAppClientSecret);
         
     }

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -40,7 +40,7 @@
 "${stack}CognitoUserPoolDomain": {
     "Type": "AWS::Cognito::UserPoolDomain",
     "Properties": {
-        "Domain": "${stack}-cognito-doimain.synapse.org",
+        "Domain": "${stack}-synapse-org",
         "UserPoolId": { "Ref": "${stack}CognitoUserPool" }
     }
 },

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -40,7 +40,16 @@
 "${stack}CognitoUserPoolDomain": {
     "Type": "AWS::Cognito::UserPoolDomain",
     "Properties": {
-    	"Domain": "${stack}-auth",
-    	"UserPoolId": { "Ref": "${stack}CognitoUserPool" }
+        "Domain": "${stack}-auth",
+        "UserPoolId": { "Ref": "${stack}CognitoUserPool" }
     }
 },
+"${stack}CognitoUserPoolUICustomization": {
+    "Type": "AWS::Cognito::UserPoolUICustomizationAttachment",
+    "Properties": {
+        "ClientId": { "Ref": "${stack}CognitoUserPoolClient" },
+        "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
+        "CSS": ".banner-customizable { background-color: #123456; }",
+        "LogoImageFile": "https://s3.us-east-1.amazonaws.com/static.synapse.org/images/synapse-logo.svg"
+    }
+}

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -21,7 +21,7 @@
     "Properties": {
         "ClientName": "${stack}-client",
         "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
-        "GenerateSecret": false,
+        "GenerateSecret": true,
         "AllowedOAuthFlows": [ "code" ],
         "AllowedOAuthScopes": [ "openid", "email" ],
         "AllowedOAuthFlowsUserPoolClient": true,

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -40,7 +40,7 @@
 "${stack}CognitoUserPoolDomain": {
     "Type": "AWS::Cognito::UserPoolDomain",
     "Properties": {
-        "Domain": "${stack}-auth",
+        "Domain": "${stack}-cognito-doimain.synapse.org",
         "UserPoolId": { "Ref": "${stack}CognitoUserPool" }
     }
 },

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -1,0 +1,46 @@
+,
+"${stack}CognitoUserPool": {
+    "Type": "AWS::Cognito::UserPool",
+    "Properties": {
+        "UserPoolName": "${stack}-user-pool",
+        "AutoVerifiedAttributes": [ "email" ],
+        "UsernameAttributes": [ "email" ],
+        "Policies": {
+            "PasswordPolicy": {
+                "MinimumLength": 8,
+                "RequireUppercase": true,
+                "RequireLowercase": true,
+                "RequireNumbers": true,
+                "RequireSymbols": true
+            }
+        }
+    }
+},
+"${stack}CognitoUserPoolClient": {
+    "Type": "AWS::Cognito::UserPoolClient",
+    "Properties": {
+        "ClientName": "${stack}-client",
+        "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
+        "GenerateSecret": false,
+        "AllowedOAuthFlows": [ "code" ],
+        "AllowedOAuthScopes": [ "openid", "email" ],
+        "AllowedOAuthFlowsUserPoolClient": true,
+        "CallbackURLs": [
+            #if(${stack} == 'dev')
+        	"http://localhost:3000/?provider=SAGE_BIONETWORKS",
+        	"https://dev.accounts.synapse.org/?provider=SAGE_BIONETWORKS"
+            #else
+         	"https://accounts.synapse.org/?provider=SAGE_BIONETWORKS",
+        	"https://staging.accounts.synapse.org/?provider=SAGE_BIONETWORKS",
+            #end
+        ],
+        "SupportedIdentityProviders": [ "COGNITO" ]
+    }
+},
+"${stack}CognitoUserPoolDomain": {
+    "Type": "AWS::Cognito::UserPoolDomain",
+    "Properties": {
+    	"Domain": "${stack}-auth",
+    	"UserPoolId": { "Ref": "${stack}CognitoUserPool" }
+    }
+},

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -4,7 +4,7 @@
     "Properties": {
         "UserPoolName": "${stack}-user-pool",
         "AutoVerifiedAttributes": [ "email" ],
-        "UsernameAttributes": [ "email" ],
+        "UsernameAttributes": [ ],
         "Policies": {
             "PasswordPolicy": {
                 "MinimumLength": 8,

--- a/src/main/resources/templates/global/cognito-user-pool.json.vpt
+++ b/src/main/resources/templates/global/cognito-user-pool.json.vpt
@@ -48,8 +48,6 @@
     "Type": "AWS::Cognito::UserPoolUICustomizationAttachment",
     "Properties": {
         "ClientId": { "Ref": "${stack}CognitoUserPoolClient" },
-        "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
-        "CSS": ".banner-customizable { background-color: #123456; }",
-        "LogoImageFile": "https://s3.us-east-1.amazonaws.com/static.synapse.org/images/synapse-logo.svg"
+        "UserPoolId": { "Ref": "${stack}CognitoUserPool" }
     }
 }

--- a/src/main/resources/templates/global/global-template.json.vpt
+++ b/src/main/resources/templates/global/global-template.json.vpt
@@ -133,14 +133,14 @@
             "Description": "Id of the shared Cognito user pool for this stack/instance.",
             "Value": { "Ref": "${stack}CognitoUserPool" },
             "Export": {
-                "Name": "CognitoUserPoolId"
+                "Name": "${CognitoUserPoolId}"
             }
         },
         "CognitoUserPoolClientId": {
             "Description": "App client id for the shared Cognito user pool for this stack/instance.",
             "Value": { "Ref": "${stack}CognitoUserPoolClient" },
             "Export": {
-                "Name": "CognitoUserPoolClientId"
+                "Name": "${CognitoUserPoolClientId}"
             }
         }
 	}

--- a/src/main/resources/templates/global/global-template.json.vpt
+++ b/src/main/resources/templates/global/global-template.json.vpt
@@ -6,6 +6,7 @@
 #parse("templates/global/webacl-cloudwatch-loggroup.json.vpt")
 #parse("templates/global/bedrock-kb-template.json.vpt")
 #parse("templates/global/rds-snapshot-encryption-key.json.vpt")
+#parse("templates/global/cognito-user-pool.json.vpt")
 	},
 	"Outputs": {
 		"NotificationTopic": {
@@ -127,6 +128,20 @@
 					]
 		        }
 		    }
-		}
+		},
+		"CognitoUserPoolId": {
+            "Description": "Id of the shared Cognito user pool for this stack/instance.",
+            "Value": { "Ref": "${stack}CognitoUserPool" },
+            "Export": {
+                "Name": "CognitoUserPoolId"
+            }
+        },
+        "CognitoUserPoolClientId": {
+            "Description": "App client id for the shared Cognito user pool for this stack/instance.",
+            "Value": { "Ref": "${stack}CognitoUserPoolClient" },
+            "Export": {
+                "Name": "CognitoUserPoolClientId"
+            }
+        }
 	}
 }

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -888,32 +888,6 @@
 		${bedrock_agent_resouces}
 		${bedrock_grid_agent_resources}
 		#parse("templates/repo/grid/grid-websocket.json.vpt")
-		,
-        "${stack}CognitoUserPool": {
-            "Type": "AWS::Cognito::UserPool",
-            "Properties": {
-                "UserPoolName": "${stack}-${instance}-user-pool",
-                "AutoVerifiedAttributes": [ "email" ],
-                "UsernameAttributes": [ "email" ],
-                "Policies": {
-                    "PasswordPolicy": {
-                        "MinimumLength": 8,
-                        "RequireUppercase": true,
-                        "RequireLowercase": true,
-                        "RequireNumbers": true,
-                        "RequireSymbols": true
-                    }
-                }
-            }
-        },
-        "${stack}CognitoUserPoolClient": {
-            "Type": "AWS::Cognito::UserPoolClient",
-            "Properties": {
-                "ClientName": "${stack}-${instance}-client",
-                "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
-                "GenerateSecret": false
-            }
-        }
 	},
 	"Outputs": {
 		#parse("templates/repo/time-to-live-out.vpt"),
@@ -1052,20 +1026,5 @@
 			}
 		}
 		#end
-		,
-		"${stack}CognitoUserPoolId": {
-            "Description": "Id of the shared Cognito user pool for this stack/instance.",
-            "Value": { "Ref": "${stack}CognitoUserPool" },
-            "Export": {
-                "Name": "${stack}-CognitoUserPoolId"
-            }
-        },
-        "${stack}CognitoUserPoolClientId": {
-            "Description": "App client id for the shared Cognito user pool for this stack/instance.",
-            "Value": { "Ref": "${stack}CognitoUserPoolClient" },
-            "Export": {
-                "Name": "${stack}-CognitoUserPoolClientId"
-            }
-        }
 	}
 }

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -889,7 +889,7 @@
 		${bedrock_grid_agent_resources}
 		#parse("templates/repo/grid/grid-websocket.json.vpt")
 		,
-        "${stack}${instance}CognitoUserPool": {
+        "${stack}CognitoUserPool": {
             "Type": "AWS::Cognito::UserPool",
             "Properties": {
                 "UserPoolName": "${stack}-${instance}-user-pool",
@@ -906,11 +906,11 @@
                 }
             }
         },
-        "${stack}${instance}CognitoUserPoolClient": {
+        "${stack}CognitoUserPoolClient": {
             "Type": "AWS::Cognito::UserPoolClient",
             "Properties": {
                 "ClientName": "${stack}-${instance}-client",
-                "UserPoolId": { "Ref": "${stack}${instance}CognitoUserPool" },
+                "UserPoolId": { "Ref": "${stack}CognitoUserPool" },
                 "GenerateSecret": false
             }
         }
@@ -1053,18 +1053,18 @@
 		}
 		#end
 		,
-		"${stack}${instance}CognitoUserPoolId": {
+		"${stack}CognitoUserPoolId": {
             "Description": "Id of the shared Cognito user pool for this stack/instance.",
-            "Value": { "Ref": "${stack}${instance}CognitoUserPool" },
+            "Value": { "Ref": "${stack}CognitoUserPool" },
             "Export": {
-                "Name": "${stack}${instance}-CognitoUserPoolId"
+                "Name": "${stack}-CognitoUserPoolId"
             }
         },
-        "${stack}${instance}CognitoUserPoolClientId": {
+        "${stack}CognitoUserPoolClientId": {
             "Description": "App client id for the shared Cognito user pool for this stack/instance.",
-            "Value": { "Ref": "${stack}${instance}CognitoUserPoolClient" },
+            "Value": { "Ref": "${stack}CognitoUserPoolClient" },
             "Export": {
-                "Name": "${stack}${instance}-CognitoUserPoolClientId"
+                "Name": "${stack}-CognitoUserPoolClientId"
             }
         }
 	}

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -888,6 +888,32 @@
 		${bedrock_agent_resouces}
 		${bedrock_grid_agent_resources}
 		#parse("templates/repo/grid/grid-websocket.json.vpt")
+		,
+        "${stack}${instance}CognitoUserPool": {
+            "Type": "AWS::Cognito::UserPool",
+            "Properties": {
+                "UserPoolName": "${stack}-${instance}-user-pool",
+                "AutoVerifiedAttributes": [ "email" ],
+                "UsernameAttributes": [ "email" ],
+                "Policies": {
+                    "PasswordPolicy": {
+                        "MinimumLength": 8,
+                        "RequireUppercase": true,
+                        "RequireLowercase": true,
+                        "RequireNumbers": true,
+                        "RequireSymbols": true
+                    }
+                }
+            }
+        },
+        "${stack}${instance}CognitoUserPoolClient": {
+            "Type": "AWS::Cognito::UserPoolClient",
+            "Properties": {
+                "ClientName": "${stack}-${instance}-client",
+                "UserPoolId": { "Ref": "${stack}${instance}CognitoUserPool" },
+                "GenerateSecret": false
+            }
+        }
 	},
 	"Outputs": {
 		#parse("templates/repo/time-to-live-out.vpt"),
@@ -1026,5 +1052,20 @@
 			}
 		}
 		#end
+		,
+		"${stack}${instance}CognitoUserPoolId": {
+            "Description": "Id of the shared Cognito user pool for this stack/instance.",
+            "Value": { "Ref": "${stack}${instance}CognitoUserPool" },
+            "Export": {
+                "Name": "${stack}${instance}-CognitoUserPoolId"
+            }
+        },
+        "${stack}${instance}CognitoUserPoolClientId": {
+            "Description": "App client id for the shared Cognito user pool for this stack/instance.",
+            "Value": { "Ref": "${stack}${instance}CognitoUserPoolClient" },
+            "Export": {
+                "Name": "${stack}${instance}-CognitoUserPoolClientId"
+            }
+        }
 	}
 }

--- a/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
@@ -172,10 +172,10 @@ public class GlobalResourcesBuilderImplTest {
         // check that the correct secret keys and values are passed
         List<CreateSecretRequest> createSecretRequests = createSecretRequestCaptor.getAllValues();
         CreateSecretRequest csr = createSecretRequests.get(0);
-        assertEquals("dev.bhoff.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
+        assertEquals("dev.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
         assertEquals("client-101", csr.secretString());
         csr = createSecretRequests.get(1);
-        assertEquals("dev.bhoff.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
+        assertEquals("dev.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
         assertEquals("secret-999", csr.secretString());
     }
 
@@ -215,10 +215,10 @@ public class GlobalResourcesBuilderImplTest {
         // check that the correct secret keys and values are passed
         List<CreateSecretRequest> createSecretRequests = createSecretRequestCaptor.getAllValues();
         CreateSecretRequest csr = createSecretRequests.get(0);
-        assertEquals("prod.bhoff.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
+        assertEquals("prod.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
         assertEquals("client-101", csr.secretString());
         csr = createSecretRequests.get(1);
-        assertEquals("prod.bhoff.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
+        assertEquals("prod.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
         assertEquals("secret-999", csr.secretString());
 
     }

--- a/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
@@ -82,8 +82,10 @@ public class GlobalResourcesBuilderImplTest {
     List<Tag> expectedTags;
 
     @Captor
-    ArgumentCaptor<CreateOrUpdateStackRequest> requestCaptor;
+    ArgumentCaptor<CreateOrUpdateStackRequest> stackRequestCaptor;
 
+    @Captor
+    ArgumentCaptor<CreateSecretRequest> createSecretRequestCaptor;
 
     GlobalResourcesBuilderImpl builder;
 
@@ -151,8 +153,8 @@ public class GlobalResourcesBuilderImplTest {
 
         builder.buildGlobalResources(); // call under test
 
-        verify(mockCloudFormationClientWrapper).createOrUpdateStack(requestCaptor.capture());
-        CreateOrUpdateStackRequest req = requestCaptor.getValue();
+        verify(mockCloudFormationClientWrapper).createOrUpdateStack(stackRequestCaptor.capture());
+        CreateOrUpdateStackRequest req = stackRequestCaptor.getValue();
         assertEquals("synapse-dev-global-resources", req.getStackName());
         assertEquals(expectedTags, req.getTags());
         assertNull(req.getParameters());
@@ -166,8 +168,15 @@ public class GlobalResourcesBuilderImplTest {
         verify(mockSesClient, never()).setComplaintNotificationTopic(anyString(), anyString());
         verify(mockSesClient, never()).setBounceNotificationTopic(anyString(), anyString());
 
-        verify(mockSecretsManager, times(2)).createSecret(any(CreateSecretRequest.class));
-        // TODO check that the correct secret keys and values are passed
+        verify(mockSecretsManager, times(2)).createSecret(createSecretRequestCaptor.capture());
+        // check that the correct secret keys and values are passed
+        List<CreateSecretRequest> createSecretRequests = createSecretRequestCaptor.getAllValues();
+        CreateSecretRequest csr = createSecretRequests.get(0);
+        assertEquals("dev.bhoff.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
+        assertEquals("client-101", csr.secretString());
+        csr = createSecretRequests.get(1);
+        assertEquals("dev.bhoff.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
+        assertEquals("secret-999", csr.secretString());
     }
 
     @Test
@@ -187,8 +196,8 @@ public class GlobalResourcesBuilderImplTest {
 
         builder.buildGlobalResources(); // call under test
 
-        verify(mockCloudFormationClientWrapper).createOrUpdateStack(requestCaptor.capture());
-        CreateOrUpdateStackRequest req = requestCaptor.getValue();
+        verify(mockCloudFormationClientWrapper).createOrUpdateStack(stackRequestCaptor.capture());
+        CreateOrUpdateStackRequest req = stackRequestCaptor.getValue();
         assertEquals("synapse-prod-global-resources", req.getStackName());
         assertEquals(expectedTags, req.getTags());
         assertNull(req.getParameters());
@@ -202,8 +211,16 @@ public class GlobalResourcesBuilderImplTest {
         verify(mockSesClient).setComplaintNotificationTopic(SES_SYNAPSE_DOMAIN, "complaintTopicArn");
         verify(mockSesClient).setBounceNotificationTopic(SES_SYNAPSE_DOMAIN, "bounceTopicArn");
 
-        verify(mockSecretsManager, times(2)).createSecret(any(CreateSecretRequest.class));
-        // TODO check that the correct secret keys and values are passed
+        verify(mockSecretsManager, times(2)).createSecret(createSecretRequestCaptor.capture());
+        // check that the correct secret keys and values are passed
+        List<CreateSecretRequest> createSecretRequests = createSecretRequestCaptor.getAllValues();
+        CreateSecretRequest csr = createSecretRequests.get(0);
+        assertEquals("prod.bhoff.org.sagebionetworks.oauth2.sagebio.client.id", csr.name());
+        assertEquals("client-101", csr.secretString());
+        csr = createSecretRequests.get(1);
+        assertEquals("prod.bhoff.org.sagebionetworks.oauth2.sagebio.client.secret", csr.name());
+        assertEquals("secret-999", csr.secretString());
+
     }
 
     private boolean validateResources(String stack, JSONObject templateJSON) {

--- a/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/global/GlobalResourcesBuilderImplTest.java
@@ -4,24 +4,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.template.Constants.GLOBAL_CFSTACK_OUTPUT_KEY_SES_BOUNCE_TOPIC;
 import static org.sagebionetworks.template.Constants.GLOBAL_CFSTACK_OUTPUT_KEY_SES_COMPLAINT_TOPIC;
 import static org.sagebionetworks.template.Constants.IDENTITY_ARN;
 import static org.sagebionetworks.template.Constants.OPS_VPC_EXPORT_PREFIX;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPS_VPC_EXPORT_PREFIX;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 import static org.sagebionetworks.template.Constants.SES_SYNAPSE_DOMAIN;
 import static org.sagebionetworks.template.Constants.STACK;
 import static org.sagebionetworks.template.Constants.VPC_EXPORT_PREFIX;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPS_VPC_EXPORT_PREFIX;
+import static software.amazon.awssdk.services.cloudformation.model.StackStatus.CREATE_COMPLETE;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,10 +42,17 @@ import org.sagebionetworks.template.CreateOrUpdateStackRequest;
 import org.sagebionetworks.template.SesClientWrapperImpl;
 import org.sagebionetworks.template.StackTagsProvider;
 import org.sagebionetworks.template.TemplateGuiceModule;
-import org.sagebionetworks.template.TemplateUtils;
 import org.sagebionetworks.template.config.Configuration;
 
+import software.amazon.awssdk.services.cloudformation.model.Output;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
 import software.amazon.awssdk.services.cloudformation.model.Tag;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DescribeUserPoolClientRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DescribeUserPoolClientResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UserPoolClientType;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
 
@@ -62,6 +71,14 @@ public class GlobalResourcesBuilderImplTest {
 	@Mock
 	StsClient mockStsClient;
 	
+	@Mock
+	SecretsManagerClient mockSecretsManager;
+	
+	@Mock
+	CognitoIdentityProviderClient mockCognitoIdentityProviderClient;
+	
+	Stack stack;
+	
     List<Tag> expectedTags;
 
     @Captor
@@ -78,8 +95,14 @@ public class GlobalResourcesBuilderImplTest {
         Tag t = Tag.builder().key("aKey").value("aValue").build();
         expectedTags.add(t);
 
-        builder = new GlobalResourcesBuilderImpl(mockCloudFormationClientWrapper, velocityEngine, mockConfig, mockStackTagsProvider, mockSesClient, mockStsClient);
+        builder = new GlobalResourcesBuilderImpl(mockCloudFormationClientWrapper, velocityEngine, mockConfig, mockStackTagsProvider, mockSesClient, mockStsClient, mockSecretsManager, mockCognitoIdentityProviderClient);
 
+        List<Output> outputs = List.of(
+        		Output.builder().outputKey("CognitoUserPoolClientId").outputValue("client-101").build(),
+        		Output.builder().outputKey("CognitoUserPoolId").outputValue("user-pool-102").build());
+        stack = Stack.builder().
+        		outputs(outputs).stackStatus(CREATE_COMPLETE).
+        		build();
     }
 
     @Test
@@ -119,6 +142,12 @@ public class GlobalResourcesBuilderImplTest {
         when(mockConfig.getProperty(PROPERTY_KEY_OPS_VPC_EXPORT_PREFIX)).thenReturn("us-east-1-vpc");
 		when(mockStsClient.getCallerIdentity()).thenReturn(GetCallerIdentityResponse.builder().arn("currentIdentityArn").build());
         when(mockStackTagsProvider.getStackTags(mockConfig)).thenReturn(expectedTags);
+        when(mockCloudFormationClientWrapper.waitForStackToComplete("synapse-dev-global-resources")).thenReturn(Optional.of(stack));
+        DescribeUserPoolClientResponse userPoolClientResponse = 
+        		DescribeUserPoolClientResponse.builder().userPoolClient(
+        				UserPoolClientType.builder().clientId("client-101").clientSecret("secret-999").build()
+        		).build();
+        when(mockCognitoIdentityProviderClient.describeUserPoolClient(any(DescribeUserPoolClientRequest.class))).thenReturn(userPoolClientResponse);
 
         builder.buildGlobalResources(); // call under test
 
@@ -137,6 +166,8 @@ public class GlobalResourcesBuilderImplTest {
         verify(mockSesClient, never()).setComplaintNotificationTopic(anyString(), anyString());
         verify(mockSesClient, never()).setBounceNotificationTopic(anyString(), anyString());
 
+        verify(mockSecretsManager, times(2)).createSecret(any(CreateSecretRequest.class));
+        // TODO check that the correct secret keys and values are passed
     }
 
     @Test
@@ -147,6 +178,12 @@ public class GlobalResourcesBuilderImplTest {
         when(mockCloudFormationClientWrapper.getOutput("synapse-prod-global-resources", GLOBAL_CFSTACK_OUTPUT_KEY_SES_COMPLAINT_TOPIC)).thenReturn("complaintTopicArn");
         when(mockCloudFormationClientWrapper.getOutput("synapse-prod-global-resources", GLOBAL_CFSTACK_OUTPUT_KEY_SES_BOUNCE_TOPIC)).thenReturn("bounceTopicArn");
         when(mockStackTagsProvider.getStackTags(mockConfig)).thenReturn(expectedTags);
+        when(mockCloudFormationClientWrapper.waitForStackToComplete("synapse-prod-global-resources")).thenReturn(Optional.of(stack));
+        DescribeUserPoolClientResponse userPoolClientResponse = 
+        		DescribeUserPoolClientResponse.builder().userPoolClient(
+        				UserPoolClientType.builder().clientId("client-101").clientSecret("secret-999").build()
+        		).build();
+        when(mockCognitoIdentityProviderClient.describeUserPoolClient(any(DescribeUserPoolClientRequest.class))).thenReturn(userPoolClientResponse);
 
         builder.buildGlobalResources(); // call under test
 
@@ -165,6 +202,8 @@ public class GlobalResourcesBuilderImplTest {
         verify(mockSesClient).setComplaintNotificationTopic(SES_SYNAPSE_DOMAIN, "complaintTopicArn");
         verify(mockSesClient).setBounceNotificationTopic(SES_SYNAPSE_DOMAIN, "bounceTopicArn");
 
+        verify(mockSecretsManager, times(2)).createSecret(any(CreateSecretRequest.class));
+        // TODO check that the correct secret keys and values are passed
     }
 
     private boolean validateResources(String stack, JSONObject templateJSON) {

--- a/src/test/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImplTest.java
@@ -2,7 +2,7 @@ package org.sagebionetworks.template.repo.beanstalk;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_INSTANCE;
@@ -21,11 +21,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.sagebionetworks.template.config.Configuration;
+import org.sagebionetworks.template.config.RepoConfiguration;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import org.sagebionetworks.template.config.RepoConfiguration;
+
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.EncryptRequest;


### PR DESCRIPTION
Add a Cognito User Pool to the stack and then put the client id and secret into Secrets Manager (SM) for the dev' stacks to pick up.  Since CF can't read the credentials from Cognito, we add a post-deployment step using the AWS client to retrieve the cred's and write to SM.