### PR TITLE
[PLFM-9513] Add search index stack builder queues

### DIFF
--- a/src/main/resources/templates/repo/opensearch-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-template.json.vpt
@@ -6,7 +6,7 @@
             "Type":"data",
             "Description":"Access policy for the stack role",
             "Policy": {
-               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[\"#[[${executionRoleArn}]]#\"]}]",
+               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DeleteIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[\"#[[${executionRoleArn}]]#\"]}]",
                 	{
                 		"executionRoleArn": 
                 		#if (${stack} == 'dev')

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -501,6 +501,18 @@
             "subscribedTopicNames": [
             ],
             "messageVisibilityTimeoutSec": 60
+		},
+		{
+			"queueName": "TABLE_SEARCH_INDEX",
+			"subscribedTopicNames": [
+				"TABLE",
+				"ENTITY_VIEW",
+				"MATERIALIZED_VIEW",
+				"TABLE_STATUS_EVENT"
+			],
+			"messageVisibilityTimeoutSec": 120,
+			"deadLetterQueueMaxFailureCount": 5,
+			"messageRetentionPeriodSec": 1209600
 		}
 	]
 }

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -31,7 +31,7 @@
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
 		"GRID_REPLICA_CHANGES",
-		"SEARCH_INDEX_DIRTY"
+		"SEARCH_INDEX"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -504,26 +504,15 @@
             "messageVisibilityTimeoutSec": 60
 		},
 		{
-			"queueName": "TABLE_SEARCH_INDEX",
+			"queueName": "SEARCH_INDEX_LIFECYCLE",
 			"subscribedTopicNames": [
-				"TABLE",
-				"ENTITY_VIEW",
-				"MATERIALIZED_VIEW",
-				"TABLE_STATUS_EVENT"
+				"SEARCH_INDEX"
 			],
 			"messageVisibilityTimeoutSec": 120,
 			"messageRetentionPeriodSec": 1209600
 		},
 		{
-			"queueName": "SEARCH_INDEX_REBUILD",
-			"subscribedTopicNames": [
-				"SEARCH_INDEX_DIRTY"
-			],
-			"messageVisibilityTimeoutSec": 120,
-			"messageRetentionPeriodSec": 1209600
-		},
-		{
-			"queueName": "TABLE_SEARCH_QUERY",
+			"queueName": "SEARCH_QUERY",
 			"subscribedTopicNames": [
 			],
 			"messageVisibilityTimeoutSec": 120,

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -166,6 +166,21 @@
 			"messageRetentionPeriodSec": 1209600
 		},
 		{
+			"queueName": "SEARCH_INDEX_LIFECYCLE",
+			"subscribedTopicNames": [
+				"ENTITY"
+			],
+			"messageVisibilityTimeoutSec": 300,
+			"deadLetterQueueMaxFailureCount": 5
+		},
+		{
+			"queueName": "SEARCH_QUERY",
+			"subscribedTopicNames": [
+			],
+			"messageVisibilityTimeoutSec": 120,
+			"oldestMessageInQueueAlarmThresholdSec": 30
+		},
+		{
 			"queueName": "TABLE_UPDATE",
 			"subscribedTopicNames": [
 				"TABLE"
@@ -502,21 +517,6 @@
             "subscribedTopicNames": [
             ],
             "messageVisibilityTimeoutSec": 60
-		},
-		{
-			"queueName": "SEARCH_INDEX_LIFECYCLE",
-			"subscribedTopicNames": [
-				"SEARCH_INDEX"
-			],
-			"messageVisibilityTimeoutSec": 120,
-			"messageRetentionPeriodSec": 1209600
-		},
-		{
-			"queueName": "SEARCH_QUERY",
-			"subscribedTopicNames": [
-			],
-			"messageVisibilityTimeoutSec": 120,
-			"oldestMessageInQueueAlarmThresholdSec": 30
 		}
 	]
 }

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -30,7 +30,8 @@
 		"ACCESS_REQUIREMENT",
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
-		"GRID_REPLICA_CHANGES"
+		"GRID_REPLICA_CHANGES",
+		"SEARCH_INDEX_DIRTY"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -511,8 +512,22 @@
 				"TABLE_STATUS_EVENT"
 			],
 			"messageVisibilityTimeoutSec": 120,
-			"deadLetterQueueMaxFailureCount": 5,
 			"messageRetentionPeriodSec": 1209600
+		},
+		{
+			"queueName": "SEARCH_INDEX_REBUILD",
+			"subscribedTopicNames": [
+				"SEARCH_INDEX_DIRTY"
+			],
+			"messageVisibilityTimeoutSec": 120,
+			"messageRetentionPeriodSec": 1209600
+		},
+		{
+			"queueName": "TABLE_SEARCH_QUERY",
+			"subscribedTopicNames": [
+			],
+			"messageVisibilityTimeoutSec": 120,
+			"oldestMessageInQueueAlarmThresholdSec": 30
 		}
 	]
 }

--- a/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
@@ -3,10 +3,13 @@ package org.sagebionetworks.template.repo.queues;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +77,38 @@ public class SnsAndSqsConfigTest {
 		SnsTopicDescriptor expectedTopic2Descriptor = new SnsTopicDescriptor(topicName2).addToSubscribedQueues(queueName).addToSubscribedQueues(queueName2);
 
 		assertEquals(Arrays.asList(expectedTopic1Descriptor, expectedTopic2Descriptor), descriptors);
+	}
+
+	@Test
+	public void testSearchIndexRebuildQueueDescriptor() {
+		List<String> allTopics = Arrays.asList("SEARCH_INDEX_DIRTY");
+		List<String> subscribedTopics = Arrays.asList("SEARCH_INDEX_DIRTY");
+
+		SqsQueueDescriptor searchIndexRebuildQueue = new SqsQueueDescriptor(
+				"SEARCH_INDEX_REBUILD",
+				subscribedTopics,
+				120,      // messageVisibilityTimeoutSec
+				null,     // deadLetterQueueMaxFailureCount
+				null,     // oldestMessageInQueueAlarmThresholdSec
+				1209600   // messageRetentionPeriodSec
+		);
+
+		SnsAndSqsConfig config = new SnsAndSqsConfig(allTopics, Collections.emptyList(),
+				Collections.singletonList(searchIndexRebuildQueue));
+
+		// Verify subscribed topic
+		Set<String> expectedTopics = new LinkedHashSet<>(Arrays.asList("SEARCH_INDEX_DIRTY"));
+		assertEquals(expectedTopics, searchIndexRebuildQueue.subscribedTopicNames);
+		assertEquals(1, searchIndexRebuildQueue.subscribedTopicNames.size());
+
+		// Verify configuration values
+		assertEquals(120, searchIndexRebuildQueue.getMessageVisibilityTimeoutSec());
+		assertNull(searchIndexRebuildQueue.getDeadLetterQueueMaxFailureCount());
+		assertEquals(1209600, searchIndexRebuildQueue.getMessageRetentionPeriodSec());
+
+		// Verify processSnsTopicDescriptors succeeds
+		List<SnsTopicDescriptor> descriptors = config.processSnsTopicDescriptors();
+		assertEquals(1, descriptors.size());
 	}
 
 }

--- a/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
@@ -3,13 +3,10 @@ package org.sagebionetworks.template.repo.queues;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -79,66 +76,5 @@ public class SnsAndSqsConfigTest {
 		assertEquals(Arrays.asList(expectedTopic1Descriptor, expectedTopic2Descriptor), descriptors);
 	}
 
-	@Test
-	public void testSearchIndexLifecycleQueueDescriptor() {
-		List<String> allTopics = Arrays.asList("ENTITY");
-		List<String> subscribedTopics = Arrays.asList("ENTITY");
-
-		SqsQueueDescriptor searchIndexLifecycleQueue = new SqsQueueDescriptor(
-				"SEARCH_INDEX_LIFECYCLE",
-				subscribedTopics,
-				300,      // messageVisibilityTimeoutSec
-				5,        // deadLetterQueueMaxFailureCount
-				null,     // oldestMessageInQueueAlarmThresholdSec
-				null      // messageRetentionPeriodSec
-		);
-
-		SnsAndSqsConfig config = new SnsAndSqsConfig(allTopics, Collections.emptyList(),
-				Collections.singletonList(searchIndexLifecycleQueue));
-
-		// Verify subscribed topic
-		Set<String> expectedTopics = new LinkedHashSet<>(Arrays.asList("ENTITY"));
-		assertEquals(expectedTopics, searchIndexLifecycleQueue.subscribedTopicNames);
-		assertEquals(1, searchIndexLifecycleQueue.subscribedTopicNames.size());
-
-		// Verify configuration values
-		assertEquals(300, searchIndexLifecycleQueue.getMessageVisibilityTimeoutSec());
-		assertEquals(5, searchIndexLifecycleQueue.getDeadLetterQueueMaxFailureCount());
-		assertNull(searchIndexLifecycleQueue.getOldestMessageInQueueAlarmThresholdSec());
-		assertNull(searchIndexLifecycleQueue.getMessageRetentionPeriodSec());
-
-		// Verify processSnsTopicDescriptors succeeds
-		List<SnsTopicDescriptor> descriptors = config.processSnsTopicDescriptors();
-		assertEquals(1, descriptors.size());
-	}
-
-	@Test
-	public void testSearchQueryQueueDescriptor() {
-		SqsQueueDescriptor searchQueryQueue = new SqsQueueDescriptor(
-				"SEARCH_QUERY",
-				Collections.emptyList(),
-				120,      // messageVisibilityTimeoutSec
-				null,     // deadLetterQueueMaxFailureCount
-				30,       // oldestMessageInQueueAlarmThresholdSec
-				null      // messageRetentionPeriodSec
-		);
-
-		SnsAndSqsConfig config = new SnsAndSqsConfig(Collections.emptyList(), Collections.emptyList(),
-				Collections.singletonList(searchQueryQueue));
-
-		// Verify no subscribed topics (async job queue)
-		assertEquals(Collections.emptySet(), searchQueryQueue.subscribedTopicNames);
-		assertEquals(0, searchQueryQueue.subscribedTopicNames.size());
-
-		// Verify configuration values
-		assertEquals(120, searchQueryQueue.getMessageVisibilityTimeoutSec());
-		assertNull(searchQueryQueue.getDeadLetterQueueMaxFailureCount());
-		assertEquals(30, searchQueryQueue.getOldestMessageInQueueAlarmThresholdSec());
-		assertNull(searchQueryQueue.getMessageRetentionPeriodSec());
-
-		// Verify processSnsTopicDescriptors succeeds with no topics
-		List<SnsTopicDescriptor> descriptors = config.processSnsTopicDescriptors();
-		assertEquals(0, descriptors.size());
-	}
 
 }

--- a/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
@@ -80,35 +80,65 @@ public class SnsAndSqsConfigTest {
 	}
 
 	@Test
-	public void testSearchIndexRebuildQueueDescriptor() {
-		List<String> allTopics = Arrays.asList("SEARCH_INDEX_DIRTY");
-		List<String> subscribedTopics = Arrays.asList("SEARCH_INDEX_DIRTY");
+	public void testSearchIndexLifecycleQueueDescriptor() {
+		List<String> allTopics = Arrays.asList("ENTITY");
+		List<String> subscribedTopics = Arrays.asList("ENTITY");
 
-		SqsQueueDescriptor searchIndexRebuildQueue = new SqsQueueDescriptor(
-				"SEARCH_INDEX_REBUILD",
+		SqsQueueDescriptor searchIndexLifecycleQueue = new SqsQueueDescriptor(
+				"SEARCH_INDEX_LIFECYCLE",
 				subscribedTopics,
-				120,      // messageVisibilityTimeoutSec
-				null,     // deadLetterQueueMaxFailureCount
+				300,      // messageVisibilityTimeoutSec
+				5,        // deadLetterQueueMaxFailureCount
 				null,     // oldestMessageInQueueAlarmThresholdSec
-				1209600   // messageRetentionPeriodSec
+				null      // messageRetentionPeriodSec
 		);
 
 		SnsAndSqsConfig config = new SnsAndSqsConfig(allTopics, Collections.emptyList(),
-				Collections.singletonList(searchIndexRebuildQueue));
+				Collections.singletonList(searchIndexLifecycleQueue));
 
 		// Verify subscribed topic
-		Set<String> expectedTopics = new LinkedHashSet<>(Arrays.asList("SEARCH_INDEX_DIRTY"));
-		assertEquals(expectedTopics, searchIndexRebuildQueue.subscribedTopicNames);
-		assertEquals(1, searchIndexRebuildQueue.subscribedTopicNames.size());
+		Set<String> expectedTopics = new LinkedHashSet<>(Arrays.asList("ENTITY"));
+		assertEquals(expectedTopics, searchIndexLifecycleQueue.subscribedTopicNames);
+		assertEquals(1, searchIndexLifecycleQueue.subscribedTopicNames.size());
 
 		// Verify configuration values
-		assertEquals(120, searchIndexRebuildQueue.getMessageVisibilityTimeoutSec());
-		assertNull(searchIndexRebuildQueue.getDeadLetterQueueMaxFailureCount());
-		assertEquals(1209600, searchIndexRebuildQueue.getMessageRetentionPeriodSec());
+		assertEquals(300, searchIndexLifecycleQueue.getMessageVisibilityTimeoutSec());
+		assertEquals(5, searchIndexLifecycleQueue.getDeadLetterQueueMaxFailureCount());
+		assertNull(searchIndexLifecycleQueue.getOldestMessageInQueueAlarmThresholdSec());
+		assertNull(searchIndexLifecycleQueue.getMessageRetentionPeriodSec());
 
 		// Verify processSnsTopicDescriptors succeeds
 		List<SnsTopicDescriptor> descriptors = config.processSnsTopicDescriptors();
 		assertEquals(1, descriptors.size());
+	}
+
+	@Test
+	public void testSearchQueryQueueDescriptor() {
+		SqsQueueDescriptor searchQueryQueue = new SqsQueueDescriptor(
+				"SEARCH_QUERY",
+				Collections.emptyList(),
+				120,      // messageVisibilityTimeoutSec
+				null,     // deadLetterQueueMaxFailureCount
+				30,       // oldestMessageInQueueAlarmThresholdSec
+				null      // messageRetentionPeriodSec
+		);
+
+		SnsAndSqsConfig config = new SnsAndSqsConfig(Collections.emptyList(), Collections.emptyList(),
+				Collections.singletonList(searchQueryQueue));
+
+		// Verify no subscribed topics (async job queue)
+		assertEquals(Collections.emptySet(), searchQueryQueue.subscribedTopicNames);
+		assertEquals(0, searchQueryQueue.subscribedTopicNames.size());
+
+		// Verify configuration values
+		assertEquals(120, searchQueryQueue.getMessageVisibilityTimeoutSec());
+		assertNull(searchQueryQueue.getDeadLetterQueueMaxFailureCount());
+		assertEquals(30, searchQueryQueue.getOldestMessageInQueueAlarmThresholdSec());
+		assertNull(searchQueryQueue.getMessageRetentionPeriodSec());
+
+		// Verify processSnsTopicDescriptors succeeds with no topics
+		List<SnsTopicDescriptor> descriptors = config.processSnsTopicDescriptors();
+		assertEquals(0, descriptors.size());
 	}
 
 }

--- a/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/queues/SnsAndSqsConfigTest.java
@@ -76,5 +76,4 @@ public class SnsAndSqsConfigTest {
 		assertEquals(Arrays.asList(expectedTopic1Descriptor, expectedTopic2Descriptor), descriptors);
 	}
 
-
 }


### PR DESCRIPTION
This pull request introduces new support for search-related queues and topics in the SNS/SQS configuration. The most important changes are the addition of new queue descriptors and topic names for search indexing and querying, as well as updates to access policies for OpenSearch.

### Search queue and topic additions

* Added `SEARCH_INDEX` to the list of SNS topic names and defined two new SQS queues: `SEARCH_INDEX_LIFECYCLE` (subscribed to `ENTITY`) and `SEARCH_QUERY` (no subscriptions, for async jobs) in `sns-and-sqs-config.json`. [[1]](diffhunk://#diff-26e74571c440db9819909479420cf0625295b1016cf1a9c42598833da99874e3L34-R35) [[2]](diffhunk://#diff-26e74571c440db9819909479420cf0625295b1016cf1a9c42598833da99874e3R169-R183)

### Access policy updates

* Updated the OpenSearch access policy to include the `aoss:DeleteIndex` permission, enabling index deletion via the stack role in `opensearch-template.json.vpt`.