### PR TITLE
[PLFM-9513] Add SEARCH_INDEX_LIFECYCLE queue and DeleteIndex permission

### DIFF
--- a/src/main/resources/templates/repo/opensearch-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-template.json.vpt
@@ -6,7 +6,7 @@
             "Type":"data",
             "Description":"Access policy for the stack role",
             "Policy": {
-               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[\"#[[${executionRoleArn}]]#\"]}]",
+               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DeleteIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[\"#[[${executionRoleArn}]]#\"]}]",
                 	{
                 		"executionRoleArn": 
                 		#if (${stack} == 'dev')

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -516,6 +516,14 @@
 				"GRID_SESSION"
 			],
 			"messageVisibilityTimeoutSec": 120
+		},
+		{
+			"queueName": "SEARCH_INDEX_LIFECYCLE",
+			"subscribedTopicNames": [
+				"ENTITY"
+			],
+			"messageVisibilityTimeoutSec": 300,
+			"deadLetterQueueMaxFailureCount": 5
 		}
 	]
 }


### PR DESCRIPTION
This pull request introduces an update to access policies for OpenSearch and adds a new SQS queue configuration for search index lifecycle events. The main changes focus on expanding permissions for index management and supporting new event-driven workflows.

**Access Policy Update:**

- Expanded the OpenSearch stack role policy in `opensearch-template.json.vpt` to include the `aoss:DeleteIndex` permission for index resources, allowing roles to delete indices as well as create, update, and describe them.

**SQS/SNS Configuration:**

- Added a new queue configuration `SEARCH_INDEX_LIFECYCLE` to `sns-and-sqs-config.json`, subscribing it to the `ENTITY` topic, with a message visibility timeout of 300 seconds and a dead letter queue max failure count of 5.