### PR TITLE
[PLFM-9517] Add SEARCH_QUERY async job SQS queue

### DIFF
--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -538,6 +538,13 @@
 			],
 			"messageVisibilityTimeoutSec": 300,
 			"deadLetterQueueMaxFailureCount": 5
+		},
+		{
+			"queueName": "SEARCH_QUERY",
+			"subscribedTopicNames": [
+			],
+			"messageVisibilityTimeoutSec": 120,
+			"oldestMessageInQueueAlarmThresholdSec": 30
 		}
 	]
 }

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -540,7 +540,7 @@
 			"deadLetterQueueMaxFailureCount": 5
 		},
 		{
-			"queueName": "SEARCH_QUERY.fifo",
+			"queueName": "SEARCH_QUERY",
 			"subscribedTopicNames": [
 			],
 			"messageVisibilityTimeoutSec": 120,

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -540,7 +540,7 @@
 			"deadLetterQueueMaxFailureCount": 5
 		},
 		{
-			"queueName": "SEARCH_QUERY",
+			"queueName": "SEARCH_QUERY.fifo",
 			"subscribedTopicNames": [
 			],
 			"messageVisibilityTimeoutSec": 120,


### PR DESCRIPTION
## Summary

Adds the `SEARCH_QUERY` SQS queue that the `SearchQueryWorker` (added in PLFM-9517 on Synapse-Repository-Services) consumes to process async `SearchIndexQuery` jobs against OpenSearch-backed SearchIndex entities.

Follows the standard async-job queue pattern (empty `subscribedTopicNames` — async jobs are enqueued directly via `AsynchJobStatusManager`, not via an SNS topic).
