### PR TITLE
[PLFM-9604] Cap STS AssumeRole duration to 1 hour on Fargate stacks

### DIFF
--- a/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
+++ b/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
@@ -385,6 +385,10 @@
 								"Value": {"Fn::ImportValue": "${sharedExportPrefix}-Temp-Credentials-Service-Role-Arn"}
 							},
 							{
+								"Name": "org.sagebionetworks.sts.duration.seconds",
+								"Value": "3600"
+							},
+							{
 								"Name": "org.sagebionetworks.cloudfront.keypair",
 								"Value": "${dataCdnKeyPairId}"
 							},


### PR DESCRIPTION
Fixes [PLFM-9604](https://sagebionetworks.jira.com/browse/PLFM-9604).

## Summary

Inject `org.sagebionetworks.sts.duration.seconds=3600` alongside the existing `org.sagebionetworks.sts.iam.arn` in the ECS-Fargate task-definition template. Without it, every Fargate-hosted Synapse stack returns HTTP 500 from `GET /repo/v1/entity/{id}/sts` and forces dependent CI jobs (e.g. synapsePythonClient integration tests) to time out at 3 hours.

## Why this is needed

`StsManagerImpl.getTemporaryCredentials()` calls AWS `AssumeRole` with `DurationSeconds = stackConfiguration.getSTSTokenDurationSeconds()` (or `DEFAULT_DURATION_SECONDS = 12*60*60` if unset). On Fargate, the task-role credentials served by the ECS Task Metadata Service are themselves STS-temp tokens (`assumed-role/...`), so calling `AssumeRole` with them is **role chaining**, and AWS hard-caps the resulting credentials at **1 hour** regardless of the role's `MaxSessionDuration`. The 12-hour default request therefore always fails with:

```
AWSSecurityTokenServiceException: The requested DurationSeconds exceeds the 1 hour
session limit for roles assumed by role chaining.
(Service: AWSSecurityTokenService; Status Code: 400; Error Code: ValidationError;
 Request ID: 49a771dc-317b-4006-a75b-530e931e72d2)
    at AWSSecurityTokenServiceClient.executeAssumeRole(AWSSecurityTokenServiceClient.java:532)
    at org.sagebionetworks.repo.manager.sts.StsManagerImpl.getTemporaryCredentials(StsManagerImpl.java:160)
```

(captured from `/ecs/repo-dev-586-0/application` CloudWatch log group at `1777064403694` ms ≈ 2026-04-24T21:00:03 UTC, during synapsePythonClient CI [run 24911508890](https://github.com/Sage-Bionetworks/synapsePythonClient/actions/runs/24911508890))

The synapsePythonClient retries 5xx via `with_retry_time_based_async` (20-min cap), so each `/sts` call hangs for 20 minutes. With pytest's `--reruns 3` × 2 STS-using tests × `-n 8` parallel workers, the integration suite was cancelled at the 3-hour CI budget.

This wasn't a problem on Beanstalk (still used for prod) because EC2 instance-profile credentials aren't subject to the role-chaining cap — `AssumeRole` honors the role's `MaxSessionDuration` (12 h) directly. The dev stack moved to ECS Fargate as part of [PLFM-9548](https://sagebionetworks.jira.com/browse/PLFM-9548) (commit f1695df6), and the new `ecs-fargate-template.json.vpt` was given the same env var injection as the Beanstalk template — but the role-chaining behavior of Fargate task credentials wasn't accounted for. dev-586 (deployed Apr 18) was the first dev stack to hit this; the synapsePythonClient CI run on Apr 24 was the first to surface it externally.

## Why 3600

3600 seconds (1 hour) is the maximum permitted under role chaining; any value ≤ 3600 works. AWS already silently capped Synapse-issued STS tokens at 1 hour on Fargate — this PR just stops the server from asking for an unreachable duration.

## Verification (independently reproduced + fix-verified on local stack)

| Local stack config | Result |
| --- | --- |
| `sts.iam.arn` unset | 500: `Value null at 'roleArn' failed to satisfy constraint` |
| `sts.iam.arn` set, no duration override | **Identical 500** as dev-586: role chaining 1-hour limit |
| `sts.iam.arn` + `sts.duration.seconds=3600` | `/sts` returns **200** with valid creds in 4.8 s; both STS integration tests **PASS in 3.4 s** |

After this PR merges and dev-586 / dev-587 redeploy with the new task definitions:

1. `aws ecs describe-task-definition --task-definition repo-dev-587-0:N` should show the new `org.sagebionetworks.sts.duration.seconds` env var.
2. `curl -H "Authorization: Bearer <token>" https://repo-dev.dev.sagebase.org/repo/v1/entity/<sts-folder-id>/sts?permission=read_only` should return 200 with credentials.
3. synapsePythonClient `TestExernalStorage::test_sts_external_storage_location` and `test_boto_upload_acl` should pass in seconds against dev.

## Side effects / risk

- **None for prod.** Prod is still on Beanstalk and unaffected.
- STS tokens issued by dev/staging shorten from a *requested* 12 h to a *requested* 1 h. AWS was already silently capping at 1 h, so no behavior actually changes for token consumers — only the redundant `ValidationError` goes away.
- When prod migrates to Fargate, prod will need this same property to avoid the same outage.

## Test plan

- [x] Stack-Builder unit tests pass locally (no test directly exercises `ecs-fargate-template.json.vpt` env vars; this is a one-line constant addition that the existing template-resolution tests cover indirectly via parsing).
- [ ] After merge: redeploy dev-587, confirm task definition contains the new env var.
- [ ] After redeploy: re-run synapsePythonClient integration suite — `test_sts_external_storage_location` and `test_boto_upload_acl` should pass in seconds, not hang for 20 min.

## Related

- [PLFM-9604](https://sagebionetworks.jira.com/browse/PLFM-9604) — this ticket
- [PLFM-9548](https://sagebionetworks.jira.com/browse/PLFM-9548) — Fargate dev migration that surfaced this
- StackConfiguration property: `org.sagebionetworks.sts.duration.seconds` (defined in `StackConfigurationImpl.java:20`)
- Synapse-Repository-Services source: `services/repository-managers/.../StsManagerImpl.java:149-161`

[PLFM-9604]: https://sagebionetworks.jira.com/browse/PLFM-9604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLFM-9548]: https://sagebionetworks.jira.com/browse/PLFM-9548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ