### PR TITLE
[PLFM-9606] Add ECS task roles as AOSS / STS principals

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -203,6 +203,7 @@ public class Constants {
 	public static final String ENVIRONMENT = "environment";
 	public static final String DB_ENDPOINT_SUFFIX = "dbEndpointSuffix";
 	public static final String REPO_BEANSTALK_NUMBER = "repoBeanstalkNumber";
+	public static final String WORKERS_BEANSTALK_NUMBER = "workersBeanstalkNumber";
 	public static final String STACK_CMK_ALIAS = "stackCMKAlias";
 	public static final String DATABASE_IDENTIFIER = "databaseIdentifier";
 	public static final String EXCEPTION_THROWER = "exceptionThrower";

--- a/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
@@ -67,6 +67,7 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_STO
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_THROUGHPUT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_VPC_SUBNET_COLOR;
 import static org.sagebionetworks.template.Constants.REPO_BEANSTALK_NUMBER;
+import static org.sagebionetworks.template.Constants.WORKERS_BEANSTALK_NUMBER;
 import static org.sagebionetworks.template.Constants.SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT;
 import static org.sagebionetworks.template.Constants.SHARED_EXPORT_PREFIX;
 import static org.sagebionetworks.template.Constants.SHARED_RESOURCES_STACK_NAME;
@@ -494,6 +495,14 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 		// Deployment target for conditional resources in shared template
 		String deploymentTarget = config.getProperty(PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS);
 		context.put(DEPLOYMENT_TARGET, deploymentTarget);
+
+		// Per-environment numbers needed by shared resources (e.g. AOSS data access policy
+		// and STS Temp Credentials trust policy must reference ECS task role names that
+		// include the env number).
+		context.put(REPO_BEANSTALK_NUMBER,
+				config.getIntegerProperty(PROPERTY_KEY_BEANSTALK_NUMBER + EnvironmentType.REPOSITORY_SERVICES.getShortName()));
+		context.put(WORKERS_BEANSTALK_NUMBER,
+				config.getIntegerProperty(PROPERTY_KEY_BEANSTALK_NUMBER + EnvironmentType.REPOSITORY_WORKERS.getShortName()));
 
 		return context;
 	}

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -793,13 +793,15 @@
 								"AWS":
 									#if(${stack} == 'dev')
 										{ "Ref": "AWS::AccountId" }
-									#elseif($deploymentTarget == "ECS_FARGATE")
-										[
-											{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-0-ecs-task-role" },
-											{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-0-ecs-task-role" }
-										]
 									#else
-										{ "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] }
+										#if($deploymentTarget == "ECS_FARGATE")
+											[
+												{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-${repoBeanstalkNumber}-ecs-task-role" },
+												{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-${workersBeanstalkNumber}-ecs-task-role" }
+											]
+										#else
+											{ "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] }
+										#end
 									#end
 							},
 							"Action": [

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -790,13 +790,17 @@
 						{
 							"Effect": "Allow",
 							"Principal": {
-								"AWS": {
+								"AWS":
 									#if(${stack} == 'dev')
-										"Ref": "AWS::AccountId"
+										{ "Ref": "AWS::AccountId" }
+									#elseif($deploymentTarget == "ECS_FARGATE")
+										[
+											{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-0-ecs-task-role" },
+											{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-0-ecs-task-role" }
+										]
 									#else
-										"Fn::GetAtt" : ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]
+										{ "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] }
 									#end
-								}
 							},
 							"Action": [
 								"sts:AssumeRole"

--- a/src/main/resources/templates/repo/opensearch-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-template.json.vpt
@@ -11,10 +11,12 @@
                 		"executionRoleArn":
                 		#if (${stack} == 'dev')
                 			{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:root\""}
-                		#elseif ($deploymentTarget == "ECS_FARGATE")
-                			{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-0-ecs-task-role\",\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-0-ecs-task-role\""}
                 		#else
-                			{"Fn::Sub": ["\"#[[${roleArn}]]#\"", {"roleArn": {"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]}}]}
+                			#if ($deploymentTarget == "ECS_FARGATE")
+                				{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-${repoBeanstalkNumber}-ecs-task-role\",\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-${workersBeanstalkNumber}-ecs-task-role\""}
+                			#else
+                				{"Fn::Sub": ["\"#[[${roleArn}]]#\"", {"roleArn": {"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]}}]}
+                			#end
                 		#end
 					}
                 ]

--- a/src/main/resources/templates/repo/opensearch-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-template.json.vpt
@@ -6,13 +6,15 @@
             "Type":"data",
             "Description":"Access policy for the stack role",
             "Policy": {
-               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DeleteIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[\"#[[${executionRoleArn}]]#\"]}]",
+               "Fn::Sub": ["[{\"Rules\":[{\"ResourceType\":\"index\",\"Resource\":[\"index/${stack}-${instance}-synsearch/*\"],\"Permission\":[\"aoss:CreateIndex\",\"aoss:DeleteIndex\",\"aoss:UpdateIndex\",\"aoss:DescribeIndex\",\"aoss:ReadDocument\",\"aoss:WriteDocument\"]},{\"ResourceType\":\"collection\",\"Resource\":[\"collection/${stack}-${instance}-synsearch\"],\"Permission\":[\"aoss:DescribeCollectionItems\",\"aoss:CreateCollectionItems\",\"aoss:UpdateCollectionItems\"]}],\"Principal\":[#[[${executionRoleArn}]]#]}]",
                 	{
-                		"executionRoleArn": 
+                		"executionRoleArn":
                 		#if (${stack} == 'dev')
-                			{"Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:root"}
+                			{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:root\""}
+                		#elseif ($deploymentTarget == "ECS_FARGATE")
+                			{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-0-ecs-task-role\",\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-0-ecs-task-role\""}
                 		#else
-                			{"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]}
+                			{"Fn::Sub": ["\"#[[${roleArn}]]#\"", {"roleArn": {"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]}}]}
                 		#end
 					}
                 ]


### PR DESCRIPTION
## Summary

Fixes [PLFM-9606](https://sagebionetworks.jira.com/browse/PLFM-9606).

The AOSS data access policy on prod-587 was denying `CreateIndex` from the new `SearchIndexLifecycleWorker` (PLFM-9513) with `[security_exception] [type=authorization_exception]`.

Root cause: ECS_FARGATE stacks sign AOSS calls as the ECS task roles (`repo-${stack}-${instance}-0-ecs-task-role` and `workers-${stack}-${instance}-0-ecs-task-role`), but the AOSS policy listed only the legacy `SynapesRepoWorkersServiceRole` as a principal. The same misalignment existed on the `SynapseTempCredentialsServiceRole` trust policy and would have surfaced the next time an ECS-based stack exercised the STS-backed S3 credential flow.

## Changes

- `templates/repo/opensearch-template.json.vpt` — `SynapseSearchCollectionDataAccessPolicy`: add an `ECS_FARGATE` branch that lists both ECS task roles as principals. Beanstalk and dev branches keep their current behavior.
- `templates/repo/main-repo-shared-resources-template.json.vpt` — `SynapseTempCredentialsServiceRole` trust policy: same `ECS_FARGATE` branch for `Principal.AWS`.

## Why ARN-by-name (not `Fn::ImportValue`)

The OpenSearch and STS resources are created in `${stack}-${instance}-shared-resources`, which deploys before the ECS stacks. Cross-stack imports aren't feasible at that point. The ECS task role names are predictable (fixed `RoleName` in `ecs-fargate-template.json.vpt`), so the ARNs can be constructed via `Fn::Sub`.

Both `Principal` fields require exact ARNs (no `*` wildcards — wildcards only work inside `Condition` operators, which is why the existing CMK key policy can use `aws:PrincipalArn` patterns). The `0` env number matches `org.sagebionetworks.stack.repo.beanstalk.number=0`.

## Already correct (no change)

- KMS CMK key policy — already has an `ECS_FARGATE` branch.
- Bedrock KB AOSS policies — use dedicated deployer / KB execution roles.

## Test plan

- [ ] Existing template-rendering tests pass.
- [ ] Re-deploy `prod-587-shared-resources` and confirm `aws opensearchserverless get-access-policy --name prod-587-synsearch --type data` lists both ECS task role ARNs as principals.
- [ ] Confirm the `prod587SynapseTempCredent…` role trust policy lists both ECS task role ARNs.
- [ ] Trigger a `SearchIndexLifecycleWorker` change message on prod-587 and confirm the index builds without `security_exception`.
- [ ] Exercise the STS temp-credentials endpoint on prod-587 ECS and confirm credentials are returned.

[PLFM-9606]: https://sagebionetworks.jira.com/browse/PLFM-9606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ