### PR TITLE
[PLFM-9614] Set placeholder Beanstalk numbers in dev buildspec

### DIFF
--- a/configuration/build/buildspec.yml
+++ b/configuration/build/buildspec.yml
@@ -14,6 +14,6 @@ phases:
       - export AWS_ACCESS_KEY_ID=$(echo $STS_CREDENTIALS | jq -r '.AccessKeyId')
       - export AWS_SECRET_KEY=$(echo $STS_CREDENTIALS | jq -r '.SecretAccessKey')
       - export AWS_SESSION_TOKEN=$(echo $STS_CREDENTIALS | jq -r '.Token')
-      - export CMD_PROPS="-Dorg.sagebionetworks.stack=dev -Dorg.sagebionetworks.instance=${user} -Dorg.sagebionetworks.vpc.subnet.color=Green"
+      - export CMD_PROPS="-Dorg.sagebionetworks.stack=dev -Dorg.sagebionetworks.instance=${user} -Dorg.sagebionetworks.vpc.subnet.color=Green -Dorg.sagebionetworks.beanstalk.number.repo=0 -Dorg.sagebionetworks.beanstalk.number.workers=0"
       - mvn clean install
       - java -Xms256m -Xmx2g -cp ./target/stack-builder-0.2.0-SNAPSHOT-jar-with-dependencies.jar $CMD_PROPS org.sagebionetworks.template.repo.RepositoryBuilderMain


### PR DESCRIPTION
## Summary

PLFM-9606 / PR #854 added two unconditional `getIntegerProperty` lookups at the end of `RepositoryTemplateBuilderImpl.createSharedContext` for `org.sagebionetworks.beanstalk.number.repo` and `.workers`. Those keys are not in `repo-defaults.properties` and were not passed by `Synapse-Stack-Builder/configuration/build/buildspec.yml`, so `RepositoryBuilderMain` (used by every developer's dev CodePipeline `RunStackBuilder` stage) now dies before any environment is built:

```
Exception in thread "main" org.sagebionetworks.template.ConfigurationPropertyNotFound: Missing property value for key: 'org.sagebionetworks.beanstalk.number.repo'
    at org.sagebionetworks.template.config.ConfigurationImpl.getProperty(ConfigurationImpl.java:47)
    at org.sagebionetworks.template.config.ConfigurationImpl.getIntegerProperty(ConfigurationImpl.java:67)
    at org.sagebionetworks.template.repo.RepositoryTemplateBuilderImpl.createSharedContext(RepositoryTemplateBuilderImpl.java:503)
    at org.sagebionetworks.template.repo.RepositoryTemplateBuilderImpl.buildAndDeploy(RepositoryTemplateBuilderImpl.java:206)
    at org.sagebionetworks.template.repo.RepositoryBuilderMain.main(RepositoryBuilderMain.java:20)
```

## Fix

Append `-Dorg.sagebionetworks.beanstalk.number.repo=0 -Dorg.sagebionetworks.beanstalk.number.workers=0` to `CMD_PROPS` in the dev buildspec. The dev pipeline only builds shared resources on the BEANSTALK target, where the templates never read these values — `0` is a placeholder that satisfies the new precondition. Real per-env Fargate deployments supply the proper numbers via their own configuration.

The deeper smell — that `createSharedContext` shouldn't require per-env values at all on the BEANSTALK path — is acknowledged but out of scope for this fix. Tracked separately if pursued.

## Test plan

- [ ] Trigger a dev `Synapse-Repository-Services` CodePipeline run; the `RunStackBuilder` stage should get past `createSharedContext` and complete the shared-resources stack deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)