### PR TITLE
removed the cycle by moving the new ECS roles to the shared resources…

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -203,7 +203,6 @@ public class Constants {
 	public static final String ENVIRONMENT = "environment";
 	public static final String DB_ENDPOINT_SUFFIX = "dbEndpointSuffix";
 	public static final String REPO_BEANSTALK_NUMBER = "repoBeanstalkNumber";
-	public static final String WORKERS_BEANSTALK_NUMBER = "workersBeanstalkNumber";
 	public static final String STACK_CMK_ALIAS = "stackCMKAlias";
 	public static final String DATABASE_IDENTIFIER = "databaseIdentifier";
 	public static final String EXCEPTION_THROWER = "exceptionThrower";

--- a/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
@@ -67,7 +67,6 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_STO
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_TABLES_RDS_THROUGHPUT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_VPC_SUBNET_COLOR;
 import static org.sagebionetworks.template.Constants.REPO_BEANSTALK_NUMBER;
-import static org.sagebionetworks.template.Constants.WORKERS_BEANSTALK_NUMBER;
 import static org.sagebionetworks.template.Constants.SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT;
 import static org.sagebionetworks.template.Constants.SHARED_EXPORT_PREFIX;
 import static org.sagebionetworks.template.Constants.SHARED_RESOURCES_STACK_NAME;
@@ -495,14 +494,6 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 		// Deployment target for conditional resources in shared template
 		String deploymentTarget = config.getProperty(PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS);
 		context.put(DEPLOYMENT_TARGET, deploymentTarget);
-
-		// Per-environment numbers needed by shared resources (e.g. AOSS data access policy
-		// and STS Temp Credentials trust policy must reference ECS task role names that
-		// include the env number).
-		context.put(REPO_BEANSTALK_NUMBER,
-				config.getIntegerProperty(PROPERTY_KEY_BEANSTALK_NUMBER + EnvironmentType.REPOSITORY_SERVICES.getShortName()));
-		context.put(WORKERS_BEANSTALK_NUMBER,
-				config.getIntegerProperty(PROPERTY_KEY_BEANSTALK_NUMBER + EnvironmentType.REPOSITORY_WORKERS.getShortName()));
 
 		return context;
 	}

--- a/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
+++ b/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
@@ -142,76 +142,6 @@
 			}
 		},
 		#end
-		"${environment.refName}TaskExecutionRole": {
-			"Type": "AWS::IAM::Role",
-			"Properties": {
-				"RoleName": "${environment.name}-ecs-execution-role",
-				"AssumeRolePolicyDocument": {
-					"Version": "2012-10-17",
-					"Statement": [
-						{
-							"Effect": "Allow",
-							"Principal": {
-								"Service": "ecs-tasks.amazonaws.com"
-							},
-							"Action": "sts:AssumeRole"
-						}
-					]
-				},
-				"ManagedPolicyArns": [
-					"arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-				]
-			}
-		},
-		"${environment.refName}TaskRole": {
-			"Type": "AWS::IAM::Role",
-			"Properties": {
-				"RoleName": "${environment.name}-ecs-task-role",
-				"AssumeRolePolicyDocument": {
-					"Version": "2012-10-17",
-					"Statement": [
-						{
-							"Effect": "Allow",
-							"Principal": {
-								"Service": "ecs-tasks.amazonaws.com"
-							},
-							"Action": "sts:AssumeRole"
-						}
-					]
-				},
-				"ManagedPolicyArns": [
-					{
-						"Fn::ImportValue": "${sharedExportPrefix}-${environment.instanceProfileSuffix}-Managed-Policy-ARN"
-					}
-					#if ($environment.isTypeRepositoryOrWorkers())
-					,
-					{
-						"Fn::ImportValue": "${sharedExportPrefix}-RepoWorkers-Bedrock-Managed-Policy-ARN"
-					}
-					#end
-				],
-				"Policies": [
-					{
-						"PolicyName": "${environment.name}-ecs-exec-policy",
-						"PolicyDocument": {
-							"Version": "2012-10-17",
-							"Statement": [
-								{
-									"Effect": "Allow",
-									"Action": [
-										"ssmmessages:CreateControlChannel",
-										"ssmmessages:CreateDataChannel",
-										"ssmmessages:OpenControlChannel",
-										"ssmmessages:OpenDataChannel"
-									],
-									"Resource": "*"
-								}
-							]
-						}
-					}
-				]
-			}
-		},
 		"${environment.refName}TaskDefinition": {
 			"Type": "AWS::ECS::TaskDefinition",
 			"Properties": {
@@ -224,10 +154,10 @@
 					"SizeInGiB": 160
 				},
 				"ExecutionRoleArn": {
-					"Fn::GetAtt": ["${environment.refName}TaskExecutionRole", "Arn"]
+					"Fn::ImportValue": "${sharedExportPrefix}-ECS-Task-Execution-Role-ARN"
 				},
 				"TaskRoleArn": {
-					"Fn::GetAtt": ["${environment.refName}TaskRole", "Arn"]
+					"Fn::ImportValue": "${sharedExportPrefix}-${environment.instanceProfileSuffix}-ECS-Task-Role-ARN"
 				},
 				"Volumes": [
 					{

--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -331,6 +331,118 @@
 				]
 			}
 		},
+		"${stack}${instance}SynapesRepoWorkersEcsTaskRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"RoleName": "${stack}-${instance}-repo-workers-ecs-task-role",
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {
+								"Service": "ecs-tasks.amazonaws.com"
+							},
+							"Action": "sts:AssumeRole"
+						}
+					]
+				},
+				"ManagedPolicyArns": [
+					"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+					{
+						"Ref": "${stack}${instance}SynapesRepoWorkersServiceManagedPolicy"
+					},
+					{
+						"Ref": "${stack}${instance}SynapesRepoWorkersBedrockManagedPolicy"
+					}
+				],
+				"Policies": [
+					{
+						"PolicyName": "${stack}-${instance}-repo-workers-ecs-exec-policy",
+						"PolicyDocument": {
+							"Version": "2012-10-17",
+							"Statement": [
+								{
+									"Effect": "Allow",
+									"Action": [
+										"ssmmessages:CreateControlChannel",
+										"ssmmessages:CreateDataChannel",
+										"ssmmessages:OpenControlChannel",
+										"ssmmessages:OpenDataChannel"
+									],
+									"Resource": "*"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		"${stack}${instance}SynapesPortalEcsTaskRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"RoleName": "${stack}-${instance}-portal-ecs-task-role",
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {
+								"Service": "ecs-tasks.amazonaws.com"
+							},
+							"Action": "sts:AssumeRole"
+						}
+					]
+				},
+				"ManagedPolicyArns": [
+					"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+					{
+						"Ref": "${stack}${instance}SynapesPortalServiceManagedPolicy"
+					}
+				],
+				"Policies": [
+					{
+						"PolicyName": "${stack}-${instance}-portal-ecs-exec-policy",
+						"PolicyDocument": {
+							"Version": "2012-10-17",
+							"Statement": [
+								{
+									"Effect": "Allow",
+									"Action": [
+										"ssmmessages:CreateControlChannel",
+										"ssmmessages:CreateDataChannel",
+										"ssmmessages:OpenControlChannel",
+										"ssmmessages:OpenDataChannel"
+									],
+									"Resource": "*"
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		"${stack}${instance}SynapesEcsTaskExecutionRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"RoleName": "${stack}-${instance}-ecs-execution-role",
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [
+						{
+							"Effect": "Allow",
+							"Principal": {
+								"Service": "ecs-tasks.amazonaws.com"
+							},
+							"Action": "sts:AssumeRole"
+						}
+					]
+				},
+				"ManagedPolicyArns": [
+					"arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+				]
+			}
+		},
 		#end
 		"${stack}${instance}ServiceSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
@@ -795,10 +907,7 @@
 										{ "Ref": "AWS::AccountId" }
 									#else
 										#if($deploymentTarget == "ECS_FARGATE")
-											[
-												{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-${repoBeanstalkNumber}-ecs-task-role" },
-												{ "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-${workersBeanstalkNumber}-ecs-task-role" }
-											]
+											{ "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersEcsTaskRole", "Arn"] }
 										#else
 											{ "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] }
 										#end
@@ -851,7 +960,7 @@
 		},
 		"${stack}${instance}CMK": {
 			"Type": "AWS::KMS::Key",
-			"DependsOn":["${stack}${instance}SynapesRepoWorkersServiceRole"],
+			"DependsOn":[#if($deploymentTarget == "ECS_FARGATE")"${stack}${instance}SynapesRepoWorkersEcsTaskRole"#else"${stack}${instance}SynapesRepoWorkersServiceRole"#end],
 			"Properties": {
 				"Description": "The master encryption key for ${stack}-${instance}",
 				"EnableKeyRotation": true,
@@ -876,8 +985,8 @@
                                         { "Fn::ImportValue": "us-east-1-synapse-${stack}-cmk-SynapseDeploymentRoleArn"},
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Deployment-Pipeline-CodeBuildServiceRole" },
                                         #if($deploymentTarget == "ECS_FARGATE")
-                                        { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-*-ecs-task-role" },
-                                        { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-*-ecs-task-role" },
+                                        { "Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersEcsTaskRole", "Arn"] },
+                                        { "Fn::GetAtt": ["${stack}${instance}SynapesPortalEcsTaskRole", "Arn"] },
                                         #else
                                         { "Fn::GetAtt": [ "${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"] },
                                         #end
@@ -1103,6 +1212,72 @@
 								"Ref": "AWS::StackName"
 							},
 							"RepoWorkers-Bedrock-Managed-Policy-ARN"
+						]
+					]
+				}
+			}
+		},
+		"RepoWorkersEcsTaskRoleArn": {
+			"Description": "The ARN of the Repo/Workers ECS task role",
+			"Value": {
+				"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersEcsTaskRole", "Arn"]
+			},
+			"Export": {
+				"Name": {
+					"Fn::Join": [
+						"-",
+						[
+							{
+								"Ref": "AWS::Region"
+							},
+							{
+								"Ref": "AWS::StackName"
+							},
+							"SynapesRepoWorkersInstanceProfile-ECS-Task-Role-ARN"
+						]
+					]
+				}
+			}
+		},
+		"PortalEcsTaskRoleArn": {
+			"Description": "The ARN of the Portal ECS task role",
+			"Value": {
+				"Fn::GetAtt": ["${stack}${instance}SynapesPortalEcsTaskRole", "Arn"]
+			},
+			"Export": {
+				"Name": {
+					"Fn::Join": [
+						"-",
+						[
+							{
+								"Ref": "AWS::Region"
+							},
+							{
+								"Ref": "AWS::StackName"
+							},
+							"SynapesPortalInstanceProfile-ECS-Task-Role-ARN"
+						]
+					]
+				}
+			}
+		},
+		"EcsTaskExecutionRoleArn": {
+			"Description": "The ARN of the shared ECS task execution role",
+			"Value": {
+				"Fn::GetAtt": ["${stack}${instance}SynapesEcsTaskExecutionRole", "Arn"]
+			},
+			"Export": {
+				"Name": {
+					"Fn::Join": [
+						"-",
+						[
+							{
+								"Ref": "AWS::Region"
+							},
+							{
+								"Ref": "AWS::StackName"
+							},
+							"ECS-Task-Execution-Role-ARN"
 						]
 					]
 				}

--- a/src/main/resources/templates/repo/opensearch-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-template.json.vpt
@@ -13,7 +13,7 @@
                 			{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:root\""}
                 		#else
                 			#if ($deploymentTarget == "ECS_FARGATE")
-                				{"Fn::Sub": "\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/repo-${stack}-${instance}-${repoBeanstalkNumber}-ecs-task-role\",\"arn:aws:iam::#[[${AWS::AccountId}]]#:role/workers-${stack}-${instance}-${workersBeanstalkNumber}-ecs-task-role\""}
+                				{"Fn::Sub": ["\"#[[${roleArn}]]#\"", {"roleArn": {"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersEcsTaskRole", "Arn"]}}]}
                 			#else
                 				{"Fn::Sub": ["\"#[[${roleArn}]]#\"", {"roleArn": {"Fn::GetAtt": ["${stack}${instance}SynapesRepoWorkersServiceRole", "Arn"]}}]}
                 			#end


### PR DESCRIPTION
….  This also removes the roles' dependency on the beanstalk number