### PR TITLE
added a new multiline pattern that tells cloudwatch to treat timesamp…

### DIFF
--- a/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
+++ b/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
@@ -266,7 +266,8 @@
 									"Ref": "${environment.refName}LogGroup"
 								},
 								"awslogs-region": "us-east-1",
-								"awslogs-stream-prefix": "ecs"
+								"awslogs-stream-prefix": "ecs",
+								"awslogs-multiline-pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
 							}
 						},
 						"Environment": [
@@ -425,7 +426,8 @@
 									"Ref": "${environment.refName}${logDesc.logType}LogGroup"
 								},
 								"awslogs-region": "us-east-1",
-								"awslogs-stream-prefix": "ecs"
+								"awslogs-stream-prefix": "ecs",
+								"awslogs-multiline-pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"
 							}
 						}
 					}


### PR DESCRIPTION
…ts in the form 2026-05-01T11:56:41 as the start of new log events.  This means any additiona lines found in traces will be included as part of the same log event.