### PR TITLE
SAGL-589

### DIFF
--- a/src/main/resources/templates/repo/ecs/nginx.conf.vpt
+++ b/src/main/resources/templates/repo/ecs/nginx.conf.vpt
@@ -10,6 +10,8 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    server_tokens off;
+
     access_log /dev/stdout;
 
     sendfile on;

--- a/src/main/resources/templates/repo/ecs/nginx.conf.vpt
+++ b/src/main/resources/templates/repo/ecs/nginx.conf.vpt
@@ -29,6 +29,8 @@ http {
         ssl_certificate_key /etc/nginx/ssl/server.key;
         ssl_protocols       TLSv1.2 TLSv1.3;
 
+        add_header X-Content-Type-Options "nosniff" always;
+
         location / {
             # Trailing slash is required — it makes nginx rewrite the upstream
             # URI from the normalized form (so "//Portal" becomes "/Portal").


### PR DESCRIPTION
Suppress response header that reveals nginx proxy internals.

Separately we were flagged for missing the “Missing 'X-Content-Type-Options' Header” header (severity level LOW).  This PR adds in that header, to clean up the web vul'n findings.