### PR TITLE
Update SNS and SQS config timeout and failure count for SEARCH_INDEX_LIFECYCLE

### DIFF
--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -536,8 +536,8 @@
 			"subscribedTopicNames": [
 				"ENTITY"
 			],
-			"messageVisibilityTimeoutSec": 300,
-			"deadLetterQueueMaxFailureCount": 5
+			"messageVisibilityTimeoutSec": 600,
+			"deadLetterQueueMaxFailureCount": 10
 		},
 		{
 			"queueName": "SEARCH_QUERY",


### PR DESCRIPTION
The `prod-591-SEARCH_INDEX_LIFECYCLE` SQS queue is processing messages during migration as expected, everything is draining and it is healthy. The issue is however that during migration the dead-letter-queue is getting messages sent to it because the underlying table the data needs to be selected from is not yet available. When the worker sees the table is not read it will throw a recoverableException -> Return it to SQS. This could happen over around 30 minutes when the stack is moved out of read-only mode. The issue is that many of the tables aren't clearing their queue within that short timeframe.

The change here is to allow for around 100 minutes of retry looping while waiting for the underlying table.


The root fix for this is to wait longer for these messages that were observed on migration:

```
   13× "Source table unavailable for entity synXXXXX, retrying: null"
        (TableUnavailableException → RecoverableMessageException at
        SearchIndexLifecycleWorker.java:74)
   13× "Recoverable exception for entity synXXXXX: Search index synXXXXX is
        already being built by another worker"
        (LockUnavilableException → RecoverableMessageException at
        SearchIndexLifecycleManagerImpl.java:175 / :189)
```