### PR TITLE
Migrate Stack-Builder-Deploy-Buckets pipeline to CodeConnections

### DIFF
--- a/.github/workflows/deploy_dev_buckets.yml
+++ b/.github/workflows/deploy_dev_buckets.yml
@@ -31,7 +31,8 @@ jobs:
           PIPELINE_PARAMETERS=\
           "Branch=$BRANCH,\
           RepoOwner=${{ github.repository_owner }},\
-          Repository=Synapse-Stack-Builder"
+          Repository=Synapse-Stack-Builder,\
+          CodeStarConnectionArn=${{ secrets.CODESTAR_CONNECTION_ARN }}"
           echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
     outputs:
       PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}

--- a/.github/workflows/deploy_dev_buckets.yml
+++ b/.github/workflows/deploy_dev_buckets.yml
@@ -28,11 +28,12 @@ jobs:
         run: |
           # capture the current branch as an environment variable
           BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+          # Note: CodeConnectionsArn is intentionally not in this list. The CFN template
+          # defaults it to the upstream connection ARN (it is non-sensitive and account-scoped).
           PIPELINE_PARAMETERS=\
           "Branch=$BRANCH,\
           RepoOwner=${{ github.repository_owner }},\
-          Repository=Synapse-Stack-Builder,\
-          CodeStarConnectionArn=${{ secrets.CODESTAR_CONNECTION_ARN }}"
+          Repository=Synapse-Stack-Builder"
           echo "PIPELINE_PARAMETERS=$PIPELINE_PARAMETERS" >> $GITHUB_OUTPUT
     outputs:
       PIPELINE_PARAMETERS: ${{ steps.pipeline-params.outputs.PIPELINE_PARAMETERS }}

--- a/configuration/build/deploy_buckets_codepipeline_cf_template.yaml
+++ b/configuration/build/deploy_buckets_codepipeline_cf_template.yaml
@@ -54,6 +54,11 @@ Parameters:
     Default: sg-0818ba0f1872103d4
     AllowedPattern: ".+"
     ConstraintDescription: Parameter cannot be empty.
+  CodeStarConnectionArn:
+    Type: String
+    Description: ARN of the CodeStar/CodeConnections GitHub connection used by the source action.
+    AllowedPattern: "arn:aws:codeconnections:.+"
+    ConstraintDescription: Must be a CodeConnections ARN.
 Outputs:
   PipelineName:
     Value: !Ref CodePipeline
@@ -92,6 +97,12 @@ Resources:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
                 Resource: !GetAtt CodeBuildProject.Arn
+              # Permission to use the CodeConnections GitHub connection from the source action
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref CodeStarConnectionArn
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -132,17 +143,18 @@ Resources:
             - Name: CheckoutStackBuilderRepo
               ActionTypeId:
                 Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
+                Owner: AWS
+                Provider: CodeStarSourceConnection
                 Version: 1
               OutputArtifacts:
                 - Name: StackBuilderRepoSource
               Configuration:
-                Owner: !Ref RepoOwner
-                Repo: !Ref Repository
-                Branch: !Ref Branch
-                OAuthToken: !Ref GitHubToken
-                PollForSourceChanges: false # instead we will trigger from GitHub workflow
+                ConnectionArn: !Ref CodeStarConnectionArn
+                FullRepositoryId: !Sub "${RepoOwner}/${Repository}"
+                BranchName: !Ref Branch
+                # Pipeline is started explicitly by the GitHub workflow via start-pipeline-execution.
+                # Leaving this true would let the connection auto-fire on every push the App sees.
+                DetectChanges: false
         - Name: DeployBuckets
           Actions:
             - Name: DeployBuckets

--- a/configuration/build/deploy_buckets_codepipeline_cf_template.yaml
+++ b/configuration/build/deploy_buckets_codepipeline_cf_template.yaml
@@ -54,9 +54,10 @@ Parameters:
     Default: sg-0818ba0f1872103d4
     AllowedPattern: ".+"
     ConstraintDescription: Parameter cannot be empty.
-  CodeStarConnectionArn:
+  CodeConnectionsArn:
     Type: String
-    Description: ARN of the CodeStar/CodeConnections GitHub connection used by the source action.
+    Description: ARN of the AWS CodeConnections GitHub connection used by the source action. The ARN is not sensitive; it is an opaque AWS identifier and grants nothing without IAM permissions.
+    Default: arn:aws:codeconnections:us-east-1:449435941126:connection/0d3d9ad4-5dfd-4294-80a5-20774dda8409
     AllowedPattern: "arn:aws:codeconnections:.+"
     ConstraintDescription: Must be a CodeConnections ARN.
 Outputs:
@@ -102,7 +103,7 @@ Resources:
                 Action:
                   - codestar-connections:UseConnection
                   - codeconnections:UseConnection
-                Resource: !Ref CodeStarConnectionArn
+                Resource: !Ref CodeConnectionsArn
   CodeBuildServiceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -149,7 +150,7 @@ Resources:
               OutputArtifacts:
                 - Name: StackBuilderRepoSource
               Configuration:
-                ConnectionArn: !Ref CodeStarConnectionArn
+                ConnectionArn: !Ref CodeConnectionsArn
                 FullRepositoryId: !Sub "${RepoOwner}/${Repository}"
                 BranchName: !Ref Branch
                 # Pipeline is started explicitly by the GitHub workflow via start-pipeline-execution.


### PR DESCRIPTION
## Summary
- The `Stack-Builder-Deploy-Buckets` CFN stack is failing `UPDATE_FAILED` with `The OAuth token used for the GitHub source action CheckoutStackBuilderRepo exceeds the maximum allowed length of 100 characters`. The shared `Sage-Bionetworks/Synapse-Code-Pipeline` workflow appends `GitHubToken=${{ secrets.GITHUB_TOKEN }}` to CFN `parameter-overrides`, and GitHub has migrated `secrets.GITHUB_TOKEN` to a longer opaque format that exceeds the v1 GitHub source action's 100-char cap.
- Migrate `CheckoutStackBuilderRepo` from the deprecated v1 GitHub action (`Owner: ThirdParty, Provider: GitHub`) to `CodeStarSourceConnection`. The new action uses a `ConnectionArn` (no length cap) instead of an `OAuthToken`, and is AWS's supported replacement.
- The connection ARN is non-sensitive (opaque AWS identifier, useless without IAM), so it's defaulted in the CFN template — no GitHub Actions secret needed.
- `DetectChanges: false` keeps the connection from auto-firing on every push the App sees; the pipeline still only runs when the GitHub workflow explicitly calls `start-pipeline-execution`. This matches the trust model used today.
- Companion PR for the larger Synapse-Repository-Services pipeline: Sage-Bionetworks/Synapse-Repository-Services#5649.

## Pre-work — already completed
The AWS CodeConnection has been created in account `449435941126` (`us-east-1`):
- ARN: `arn:aws:codeconnections:us-east-1:449435941126:connection/0d3d9ad4-5dfd-4294-80a5-20774dda8409` (defaulted in the template)
- Verify the GitHub App install scope in `Sage-Bionetworks` org GitHub settings is limited to `Synapse-Stack-Builder` (and `Synapse-Repository-Services` for the companion PR).

## Required follow-up

### 1. (If needed) recover the stuck stack
- If `Stack-Builder-Deploy-Buckets` is in `UPDATE_ROLLBACK_FAILED`:
  ```
  aws cloudformation continue-update-rollback --stack-name Stack-Builder-Deploy-Buckets --region us-east-1
  ```
- If it's in `UPDATE_FAILED` (rollback already completed), the next workflow run will attempt a normal update — no manual recovery needed.

### 2. Merge this PR
The `push: develop` trigger on `deploy_dev_buckets.yml` fires the workflow, which calls the shared `execute_code_pipeline.yml`, which now uses the template-default ARN.

## Test plan
- [ ] Stack `Stack-Builder-Deploy-Buckets` updates without the `OAuth token … exceeds the maximum allowed length` event.
- [ ] In the AWS console, `CheckoutStackBuilderRepo` shows `Source provider: GitHub (via AWS CodeStar)` and pulls the expected commit.
- [ ] `DeployBuckets` runs `mvn clean install` and `S3BuilderMain` to a successful exit.
- [ ] Confirm the GitHub App install in `Sage-Bionetworks` org settings is scoped only to the intended repos.