### PR TITLE
PLFM-9715: Enable automated backups on dev stack

### DIFF
--- a/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
@@ -528,7 +528,7 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 				.withDbThroughput(config.getIntegerProperty(PROPERTY_KEY_REPO_RDS_THROUGHPUT))
 				.withMultiAZ(config.getBooleanProperty(PROPERTY_KEY_REPO_RDS_MULTI_AZ))
 				// 0 indicates no automated backups will be created.
-				.withBackupRetentionPeriodDays(Constants.isProd(stack) ? 7 : 0)
+				.withBackupRetentionPeriodDays(7)
 				.withDeletionPolicy(Constants.isProd(stack)? DeletionPolicy.Snapshot: DeletionPolicy.Delete);
 		
 

--- a/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
@@ -1546,7 +1546,7 @@ public class RepositoryTemplateBuilderImplTest {
 		DatabaseDescriptor[] results = builder.createDatabaseDescriptors();
 		DatabaseDescriptor[] expected = new DatabaseDescriptor[] {
 				// repo
-				new DatabaseDescriptor().withAllocatedStorage(4).withBackupRetentionPeriodDays(0)
+				new DatabaseDescriptor().withAllocatedStorage(4).withBackupRetentionPeriodDays(7)
 						.withDbIops(-1).withDbThroughput(-1)
 						.withDbName("dev101").withDbStorageType(DatabaseStorageType.standard.name())
 						.withInstanceClass("db.t2.small").withInstanceIdentifier("dev-101-db")


### PR DESCRIPTION
This PR enables automated backups on the dev stack. This is need to allow using the dev stack to test the Snowflake ingestion process in DPE.