### PR TITLE
PLFM-9660

### DIFF
--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -1028,6 +1028,7 @@
 		#parse("templates/repo/kinesis-log-streams.json.vpt")
 		#parse("templates/repo/step-functions-template.json.vpt")
 		#parse("templates/repo/cloudwatch-alarms-template.json.vpt")
+		#parse("templates/repo/staging-alarm-mute-template.json.vpt")
 		#parse("templates/repo/web/acl/web-acl-template.json.vpt")
 		#parse("templates/repo/appconfig-template.json.vpt")
 		#parse("templates/repo/api-gateway-template.json.vpt")

--- a/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
+++ b/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
@@ -1,0 +1,156 @@
+
+#if(${stack} == 'prod')
+	,
+	"${stack}${instance}StagingAlarmMuteLambdaRole": {
+		"Type": "AWS::IAM::Role",
+		"Properties": {
+			"AssumeRolePolicyDocument": {
+				"Version": "2012-10-17",
+				"Statement": [
+					{
+						"Effect": "Allow",
+						"Principal": {
+							"Service": "lambda.amazonaws.com"
+						},
+						"Action": "sts:AssumeRole"
+					}
+				]
+			},
+			"Path": "/",
+			"Policies": [
+				{
+					"PolicyName": "staging-alarm-mute-policy",
+					"PolicyDocument": {
+						"Version": "2012-10-17",
+						"Statement": [
+							{
+								"Effect": "Allow",
+								"Action": [
+									"logs:CreateLogGroup",
+									"logs:CreateLogStream",
+									"logs:PutLogEvents"
+								],
+								"Resource": {
+									"Fn::Sub": "arn:aws:logs:#[[${AWS::Region}:${AWS::AccountId}]]#:log-group:/aws/lambda/${stack}-${instance}-staging-alarm-mute:*"
+								}
+							},
+							{
+								"Effect": "Allow",
+								"Action": [
+									"cloudwatch:DescribeAlarms",
+									"cloudwatch:PutAlarmMuteRule",
+									"cloudwatch:DeleteAlarmMuteRules"
+								],
+								"Resource": "*"
+							}
+						]
+					}
+				}
+			]
+		}
+	},
+	"${stack}${instance}StagingAlarmMuteLambda": {
+		"Type": "AWS::Lambda::Function",
+		"Properties": {
+			"FunctionName": "${stack}-${instance}-staging-alarm-mute",
+			"Handler": "index.handler",
+			"Role": {"Fn::GetAtt": ["${stack}${instance}StagingAlarmMuteLambdaRole", "Arn"]},
+			"Runtime": "python3.12",
+			"Timeout": 60,
+			"Environment": {
+				"Variables": {
+					"STACK_INSTANCE": "${instance}",
+					"STACK_NAME": "${stack}"
+				}
+			},
+			"Code": {
+				"ZipFile": {
+					"Fn::Join": [
+						"\n",
+						[
+							"import json, os, boto3",
+							"from datetime import datetime, timezone, timedelta",
+							"from urllib.request import urlopen, Request",
+							"",
+							"STAGING_URL = 'https://repo-staging.prod.sagebase.org/repo/v1/version'",
+							"",
+							"def handler(event, context):",
+							"    instance = os.environ['STACK_INSTANCE']",
+							"    stack = os.environ['STACK_NAME']",
+							"    rule_name = f'{stack}-{instance}-staging-alarm-mute'",
+							"",
+							"    try:",
+							"        with urlopen(Request(STAGING_URL), timeout=10) as resp:",
+							"            staging_instance = json.loads(resp.read()).get('stackInstance', '')",
+							"    except Exception as e:",
+							"        print(f'Cannot reach staging endpoint: {e}')",
+							"        return",
+							"",
+							"    is_staging = str(staging_instance) == str(instance)",
+							"    cw = boto3.client('cloudwatch')",
+							"",
+							"    if not is_staging:",
+							"        try:",
+							"            cw.delete_alarm_mute_rules(Names=[rule_name])",
+							"        except Exception:",
+							"            pass",
+							"        return",
+							"",
+							"    alarm_names = []",
+							"    paginator = cw.get_paginator('describe_alarms')",
+							"    for page in paginator.paginate(AlarmTypes=['MetricAlarm', 'CompositeAlarm']):",
+							"        for alarm in page.get('MetricAlarms', []) + page.get('CompositeAlarms', []):",
+							"            name = alarm['AlarmName']",
+							"            if f'-{instance}-' in name or name.startswith(f'repo{instance}'):",
+							"                alarm_names.append(name)",
+							"",
+							"    if not alarm_names:",
+							"        return",
+							"",
+							"    now = datetime.now(timezone.utc) + timedelta(minutes=1)",
+							"    at_expr = f\"at({now.strftime('%Y-%m-%dT%H:%M')})\"",
+							"",
+							"    cw.put_alarm_mute_rule(",
+							"        Name=rule_name,",
+							"        MuteTargets={'AlarmNames': alarm_names[:100]},",
+							"        Rule={'Schedule': {'Expression': at_expr, 'Duration': 'PT10M', 'Timezone': 'UTC'}}",
+							"    )",
+							"    print(f'Mute rule set for {len(alarm_names)} alarms (instance {instance})')"
+						]
+					]
+				}
+			}
+		}
+	},
+	"${stack}${instance}StagingAlarmMuteSchedule": {
+		"Type": "AWS::Events::Rule",
+		"Properties": {
+			"ScheduleExpression": "rate(5 minutes)",
+			"Targets": [
+				{
+					"Arn": {
+						"Fn::GetAtt": ["${stack}${instance}StagingAlarmMuteLambda", "Arn"]
+					},
+					"Id": "staging-alarm-mute-5min"
+				}
+			]
+		}
+	},
+	"${stack}${instance}StagingAlarmMuteLambdaPermission": {
+		"Type": "AWS::Lambda::Permission",
+		"DependsOn": [
+			"${stack}${instance}StagingAlarmMuteLambda",
+			"${stack}${instance}StagingAlarmMuteSchedule"
+		],
+		"Properties": {
+			"FunctionName": {
+				"Fn::GetAtt": ["${stack}${instance}StagingAlarmMuteLambda", "Arn"]
+			},
+			"Action": "lambda:invokeFunction",
+			"Principal": "events.amazonaws.com",
+			"SourceArn": {
+				"Fn::GetAtt": ["${stack}${instance}StagingAlarmMuteSchedule", "Arn"]
+			}
+		}
+	}
+#end

--- a/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
+++ b/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
@@ -69,16 +69,43 @@
 						"\n",
 						[
 							"import json, os, boto3",
-							"from datetime import datetime, timezone, timedelta",
+							"from datetime import datetime, timezone",
 							"from urllib.request import urlopen, Request",
 							"",
 							"STAGING_URL = 'https://repo-staging.prod.sagebase.org/repo/v1/version'",
+							"",
+							"def send_cfn_response(event, context, status):",
+							"    import urllib.request",
+							"    body = json.dumps({",
+							"        'Status': status,",
+							"        'Reason': f'See CloudWatch Log Stream: {context.log_stream_name}',",
+							"        'PhysicalResourceId': context.log_stream_name,",
+							"        'StackId': event['StackId'],",
+							"        'RequestId': event['RequestId'],",
+							"        'LogicalResourceId': event['LogicalResourceId']",
+							"    }).encode('utf-8')",
+							"    req = urllib.request.Request(event['ResponseURL'], data=body, method='PUT')",
+							"    req.add_header('Content-Type', '')",
+							"    req.add_header('Content-Length', str(len(body)))",
+							"    urllib.request.urlopen(req)",
 							"",
 							"def handler(event, context):",
 							"    instance = os.environ['STACK_INSTANCE']",
 							"    stack = os.environ['STACK_NAME']",
 							"    rule_name = f'{stack}-{instance}-staging-alarm-mute'",
 							"",
+							"    # Handle CloudFormation Custom Resource events",
+							"    if 'RequestType' in event:",
+							"        if event['RequestType'] == 'Delete':",
+							"            cw = boto3.client('cloudwatch')",
+							"            try:",
+							"                cw.delete_alarm_mute_rules(Names=[rule_name])",
+							"            except Exception as e:",
+							"                print(f'Cleanup failed: {e}')",
+							"        send_cfn_response(event, context, 'SUCCESS')",
+							"        return",
+							"",
+							"    # Scheduled event: check if this instance is staging",
 							"    try:",
 							"        with urlopen(Request(STAGING_URL), timeout=10) as resp:",
 							"            staging_instance = json.loads(resp.read()).get('stackInstance', '')",
@@ -119,6 +146,15 @@
 						]
 					]
 				}
+			}
+		}
+	},
+	"${stack}${instance}StagingAlarmMuteCleanup": {
+		"Type": "Custom::StagingAlarmMuteCleanup",
+		"DependsOn": ["${stack}${instance}StagingAlarmMuteLambda"],
+		"Properties": {
+			"ServiceToken": {
+				"Fn::GetAtt": ["${stack}${instance}StagingAlarmMuteLambda", "Arn"]
 			}
 		}
 	},

--- a/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
+++ b/src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt
@@ -107,7 +107,7 @@
 							"    if not alarm_names:",
 							"        return",
 							"",
-							"    now = datetime.now(timezone.utc) + timedelta(minutes=1)",
+							"    now = datetime.now(timezone.utc)",
 							"    at_expr = f\"at({now.strftime('%Y-%m-%dT%H:%M')})\"",
 							"",
 							"    cw.put_alarm_mute_rule(",


### PR DESCRIPTION
  1. Created `src/main/resources/templates/repo/staging-alarm-mute-template.json.vpt` — a new Velocity template with a Lambda + EventBridge schedule + IAM role + permission, all gated by #if(${stack} == 'prod'). The Lambda runs every 5 minutes, checks if the current instance is staging, and if so creates a 10-minute  auto-expiring AlarmMuteRule covering all alarms for that instance.  The alarms it looks for are ones that have either of these patterns: '-{instance}-' 'repo{instance}'.
  2. Modified src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt — added a #parse directive to include the new template.

