### PR TITLE
PLFM-8573: Move S3 calls to APIv2

### DIFF
--- a/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.template.markdownit;
 
-import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.Inject;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
@@ -14,8 +13,11 @@ import org.sagebionetworks.template.CreateOrUpdateStackRequest;
 import org.sagebionetworks.template.StackTagsProvider;
 import org.sagebionetworks.template.config.RepoConfiguration;
 import org.sagebionetworks.template.utils.ArtifactDownload;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.cloudformation.model.Capability;
 import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.StringWriter;
@@ -38,14 +40,14 @@ public class MarkDownItLambdaBuilderImpl implements MarkDownItLambdaBuilder {
 
     private StackTagsProvider tagsProvider;
 
-    private AmazonS3 s3Client;
+    private S3Client s3Client;
 
     private VelocityEngine velocityEngine;
 
     @Inject
     public MarkDownItLambdaBuilderImpl(RepoConfiguration config,
                                        ArtifactDownload downloader, CloudFormationClientWrapper cloudFormationClientWrapper,
-                                       StackTagsProvider tagsProvider, AmazonS3 s3Client,
+                                       StackTagsProvider tagsProvider, S3Client s3Client,
                                        VelocityEngine velocityEngine) {
         this.config = config;
         this.downloader = downloader;
@@ -67,7 +69,13 @@ public class MarkDownItLambdaBuilderImpl implements MarkDownItLambdaBuilder {
         // Download from jfrog and upload to S3
         File artifact = downloader.downloadFile(lambdaSourceArtifactUrl);
         try {
-            s3Client.putObject(artifactBucket, lambdaArtifactKey, artifact);
+            s3Client.putObject(
+                PutObjectRequest.builder()
+                    .bucket(artifactBucket)
+                    .key(lambdaArtifactKey)
+                    .build(),
+                RequestBody.fromFile(artifact)
+            );
         } finally {
             artifact.delete();
         }

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -25,15 +25,11 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.sagebionetworks.template.Constants.CAPABILITY_NAMED_IAM;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
@@ -102,7 +98,7 @@ public class MarkDownItLambdaBuilderImplTest {
         ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
         ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
         verify(mockS3Client).putObject(putRequestCaptor.capture(), requestBodyCaptor.capture());
-
+        assertNotNull(requestBodyCaptor.getValue());
         PutObjectRequest capturedRequest = putRequestCaptor.getValue();
         assertEquals(expectedBucket, capturedRequest.bucket());
         assertEquals(expectedKey, capturedRequest.key());
@@ -131,6 +127,8 @@ public class MarkDownItLambdaBuilderImplTest {
 
         assertEquals("dev-markdown-it-function", argCaptorWaitForStack.getValue());
         assertEquals("dev-markdown-it-function", argCaptorDescribeStack.getValue());
+
+        assertFalse(testFile.exists());
 
     }
 

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.template.markdownit;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.apache.velocity.app.VelocityEngine;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,10 +14,14 @@ import org.sagebionetworks.template.StackTagsProvider;
 import org.sagebionetworks.template.TemplateGuiceModule;
 import org.sagebionetworks.template.config.RepoConfiguration;
 import org.sagebionetworks.template.utils.ArtifactDownload;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.cloudformation.model.Capability;
 import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -26,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -49,22 +53,20 @@ public class MarkDownItLambdaBuilderImplTest {
     StackTagsProvider mockTagsProvider;
 
     @Mock
-    AmazonS3 mockS3Client;
+    S3Client mockS3Client;
 
     VelocityEngine velocityEngine;
 
-    @Mock
-    File mockFile;
-
-
     private String stack;
+    private File testFile;
 
     @BeforeEach
-    public void before() {
+    public void before() throws Exception {
         stack = "dev";
         when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
         when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET)).thenReturn("lambda.sagebase.org");
         when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL)).thenReturn("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdownit.zip");
+        testFile = Files.createTempFile("test", ".zip").toFile();
     }
 
     @Test
@@ -81,7 +83,7 @@ public class MarkDownItLambdaBuilderImplTest {
                 velocityEngine);
 
 
-        when(mockDownloader.downloadFile(any())).thenReturn(mockFile);
+        when(mockDownloader.downloadFile(any())).thenReturn(testFile);
 
         when(mockTagsProvider.getStackTags(mockConfig)).thenReturn(Collections.emptyList());
 
@@ -96,9 +98,14 @@ public class MarkDownItLambdaBuilderImplTest {
         builder.buildMarkDownItLambda();
 
         verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdownit.zip");
-        verify(mockS3Client).putObject(expectedBucket, expectedKey, mockFile);
 
-        verify(mockFile).delete();
+        ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(mockS3Client).putObject(putRequestCaptor.capture(), requestBodyCaptor.capture());
+
+        PutObjectRequest capturedRequest = putRequestCaptor.getValue();
+        assertEquals(expectedBucket, capturedRequest.bucket());
+        assertEquals(expectedKey, capturedRequest.key());
 
         ArgumentCaptor<CreateOrUpdateStackRequest> argCaptorCreateOrUpdateStack = ArgumentCaptor.forClass(CreateOrUpdateStackRequest.class);
         ArgumentCaptor<String> argCaptorWaitForStack = ArgumentCaptor.forClass(String.class);


### PR DESCRIPTION
This PR just changes move to S3 v2 for markdown-it. 
I think the only comment is li:77, the fromFile() method requires a real file.