### PR TITLE
PLFM-9788: Match OpenSearch subnets to instance-type availability zones

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -95,6 +95,9 @@ public class Constants {
 	public static final String PROPERTY_KEY_ID_GENERATOR_HOSTED_ZONE_ID = "org.sagebionetworks.id.generator.hosted.zone.id";
 	public static final String PROPERTY_KEY_EC2_INSTANCE_TYPE = "org.sagebionetworks.beanstalk.instance.type";
 	public static final String PROPERTY_KEY_EC2_INSTANCE_MEMORY = "org.sagebionetworks.beanstalk.instance.memory";
+	public static final String PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE = "org.sagebionetworks.opensearch.instance.type";
+	public static final String PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE = "org.sagebionetworks.opensearch.master.instance.type";
+	public static final String PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT = "org.sagebionetworks.opensearch.availability.zone.count";
 	public static final String PROPERTY_KEY_TIME_TO_LIVE_HOURS = "org.sagebionetworks.repo.time.to.live.hours";
 
 	public static final String PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_PREFIX = "org.sagebionetworks.beanstalk.image.version.";
@@ -189,6 +192,10 @@ public class Constants {
 
 	// context keys
 	public static final String SUBNETS = "subnets";
+	public static final String OPENSEARCH_SUBNETS = "openSearchSubnets";
+	public static final String OPENSEARCH_INSTANCE_TYPE = "openSearchInstanceType";
+	public static final String OPENSEARCH_MASTER_INSTANCE_TYPE = "openSearchMasterInstanceType";
+	public static final String OPENSEARCH_AVAILABILITY_ZONE_COUNT = "openSearchAvailabilityZoneCount";
 	public static final String VPC_CIDR = "vpcCidr";
 	public static final String VPC_SUBNET_COLOR = "subnetGroupColor";
 	public static final String STACK = "stack";

--- a/src/main/java/org/sagebionetworks/template/Ec2ClientWrapper.java
+++ b/src/main/java/org/sagebionetworks/template/Ec2ClientWrapper.java
@@ -8,5 +8,6 @@ public interface Ec2ClientWrapper {
 	public List<String> getAvailabilityZonesForInstanceType(String instanceType);
 	public Map<String, String> getAvailabityZoneToSubnetMap(List<String> subnetIds);
 	public List<String> getAvailableSubnetsForInstanceType(String instanceType, List<String> subnets);
+	public List<String> getAvailableSubnetsForInstanceTypes(List<String> instanceTypes, List<String> subnets, int minCount);
 
 }

--- a/src/main/java/org/sagebionetworks/template/Ec2ClientWrapperImpl.java
+++ b/src/main/java/org/sagebionetworks/template/Ec2ClientWrapperImpl.java
@@ -15,9 +15,11 @@ import software.amazon.awssdk.services.ec2.model.Subnet;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class Ec2ClientWrapperImpl implements Ec2ClientWrapper {
@@ -57,11 +59,25 @@ public class Ec2ClientWrapperImpl implements Ec2ClientWrapper {
 
 	@Override
 	public List<String> getAvailableSubnetsForInstanceType(String instanceType, List<String> subnets) {
+		return getAvailableSubnetsForInstanceTypes(List.of(instanceType), subnets, 2);
+	}
+
+	@Override
+	public List<String> getAvailableSubnetsForInstanceTypes(List<String> instanceTypes, List<String> subnets, int minCount) {
 		Map<String, String> zoneToSubnetMap = getAvailabityZoneToSubnetMap(subnets);
-		List<String> availableZones = getAvailabilityZonesForInstanceType(instanceType);
-		List<String> availableSubnets = availableZones.stream().map(z -> zoneToSubnetMap.get(z)).filter(Objects::nonNull).sorted().collect(Collectors.toList());
-		if (availableSubnets.size() < 2) {
-			throw new IllegalArgumentException(String.format("Could not find 2 available subnets for type %s in %s ", instanceType, subnets));
+		// Availability zones that offer every requested instance type.
+		Set<String> commonZones = null;
+		for (String instanceType : instanceTypes) {
+			List<String> zones = getAvailabilityZonesForInstanceType(instanceType);
+			if (commonZones == null) {
+				commonZones = new HashSet<>(zones);
+			} else {
+				commonZones.retainAll(zones);
+			}
+		}
+		List<String> availableSubnets = commonZones.stream().map(zoneToSubnetMap::get).filter(Objects::nonNull).sorted().collect(Collectors.toList());
+		if (availableSubnets.size() < minCount) {
+			throw new IllegalArgumentException(String.format("Could not find %d available subnets for types %s in %s ", minCount, instanceTypes, subnets));
 		}
 		return availableSubnets;
 	}

--- a/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
@@ -39,6 +39,9 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DATA_CDN_PRIVA
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_MEMORY;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ECS_CONTAINER_PORT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ECS_TASK_CPU;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ECS_TASK_MEMORY;
@@ -500,6 +503,23 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 		// Deployment target for conditional resources in shared template
 		String deploymentTarget = config.getProperty(PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS);
 		context.put(DEPLOYMENT_TARGET, deploymentTarget);
+
+		// The prod OpenSearch domain is VPC-attached and pinned to specific data and dedicated
+		// master instance types, which are not offered in every AZ. Resolve the color's private
+		// subnets and keep only those in AZs that offer both types, so the domain is never placed
+		// in an AZ that cannot host one of its node types.
+		if (Constants.isProd(stack)) {
+			String openSearchInstanceType = config.getProperty(PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE);
+			String openSearchMasterInstanceType = config.getProperty(PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE);
+			int openSearchAvailabilityZoneCount = config.getIntegerProperty(PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT);
+			context.put(Constants.OPENSEARCH_INSTANCE_TYPE, openSearchInstanceType);
+			context.put(Constants.OPENSEARCH_MASTER_INSTANCE_TYPE, openSearchMasterInstanceType);
+			context.put(Constants.OPENSEARCH_AVAILABILITY_ZONE_COUNT, openSearchAvailabilityZoneCount);
+			List<String> vpcSubnets = getPrivateSubnets(config.getProperty(PROPERTY_KEY_VPC_SUBNET_COLOR));
+			List<String> availableSubnets = ec2ClientWrapper.getAvailableSubnetsForInstanceTypes(
+					List.of(openSearchInstanceType, openSearchMasterInstanceType), vpcSubnets, openSearchAvailabilityZoneCount);
+			context.put(Constants.OPENSEARCH_SUBNETS, availableSubnets.subList(0, openSearchAvailabilityZoneCount));
+		}
 
 		return context;
 	}

--- a/src/main/resources/templates/repo/opensearch-managed-template.json.vpt
+++ b/src/main/resources/templates/repo/opensearch-managed-template.json.vpt
@@ -42,21 +42,19 @@
 		"Properties": {
 			"DomainName": "${stack}-${instance}-synidx",
 			"EngineVersion": "OpenSearch_3.5",
-			## AvailabilityZoneCount drives both ZoneAwarenessConfig below and the number of
-			## subnets selected in VPCOptions.SubnetIds further down - change it in one place.
-			#set($availabilityZoneCount = 1)
-			#if (${stack} == 'prod')
-			#set($availabilityZoneCount = 2)
-			#end
+			## For prod, openSearchInstanceType / openSearchMasterInstanceType /
+			## openSearchAvailabilityZoneCount and the pruned openSearchSubnets list are all injected
+			## from RepositoryTemplateBuilderImpl. The AZ count drives ZoneAwarenessConfig here and
+			## bounds the subnet list length there.
 			"ClusterConfig":
 				#if (${stack} == 'prod')
 				{
-					"InstanceType": "r6g.xlarge.search",
+					"InstanceType": "${openSearchInstanceType}.search",
 					"InstanceCount": 2,
 					"ZoneAwarenessEnabled": true,
-					"ZoneAwarenessConfig": { "AvailabilityZoneCount": $availabilityZoneCount },
+					"ZoneAwarenessConfig": { "AvailabilityZoneCount": $openSearchAvailabilityZoneCount },
 					"DedicatedMasterEnabled": true,
-					"DedicatedMasterType": "m6g.large.search",
+					"DedicatedMasterType": "${openSearchMasterInstanceType}.search",
 					"DedicatedMasterCount": 3
 				}
 				#else
@@ -99,14 +97,11 @@
 				"SecurityGroupIds": [
 					{ "Ref": "${stack}${instance}SynapseSearchIndexSecurityGroup" }
 				],
-				"SubnetIds":
-					[
-						#set($lastAvailabilityZoneIndex = $availabilityZoneCount - 1)
-						#foreach($availabilityZoneIndex in [0..$lastAvailabilityZoneIndex])
-						#if($foreach.count > 1),#end
-						{ "Fn::Select": [ $availabilityZoneIndex, { "Fn::Split": [ ", ", { "Fn::ImportValue": "${vpcExportPrefix}-private-subnets-${subnetGroupColor}-Private-Subnets" } ] } ] }
-						#end
-					]
+				"SubnetIds": [
+					#foreach($subnetId in $openSearchSubnets)
+						"$subnetId"#if($foreach.hasNext),#end
+					#end
+				]
 			},
 			#end
 			"AccessPolicies": {

--- a/src/main/resources/templates/repo/repo-defaults.properties
+++ b/src/main/resources/templates/repo/repo-defaults.properties
@@ -36,6 +36,15 @@ org.sagebionetworks.enable.rds.enhanced.monitoring=false
 org.sagebionetworks.beanstalk.instance.type=t3.medium
 org.sagebionetworks.beanstalk.instance.memory=3328
 
+# EC2 instance types backing the prod OpenSearch domain's data and dedicated master nodes (bare
+# EC2 types; the domain template renders each as "<type>.search"). Used to query per-AZ
+# availability so the domain is only placed in subnets whose AZ offers both types.
+org.sagebionetworks.opensearch.instance.type=r6g.xlarge
+org.sagebionetworks.opensearch.master.instance.type=m6g.large
+# Number of AZs the prod OpenSearch domain spans: sets ZoneAwarenessConfig.AvailabilityZoneCount
+# and the number of pruned subnets attached to the domain.
+org.sagebionetworks.opensearch.availability.zone.count=2
+
 # Beanstalk health check urls
 org.sagebionetworks.beanstalk.health.check.url.repo=/repo/v1/version
 org.sagebionetworks.beanstalk.health.check.url.workers=/

--- a/src/test/java/org/sagebionetworks/template/Ec2ClientWrapperImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/Ec2ClientWrapperImplTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -121,8 +123,60 @@ class Ec2ClientWrapperImplTest {
 		// Call under test
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
 			ec2ClientWrapper.getAvailableSubnetsForInstanceType(INSTANCE_TYPE, subnets);});
-		assertEquals(String.format("Could not find 2 available subnets for type %s in %s ", INSTANCE_TYPE, subnets), e.getMessage());
+		assertEquals(String.format("Could not find 2 available subnets for types %s in %s ", List.of(INSTANCE_TYPE), subnets), e.getMessage());
 
+	}
+
+	@Test
+	void getAvailableSubnetsForInstanceTypes() {
+		String dataType = "r6g.xlarge";
+		String masterType = "m6g.large";
+		when(mockEC2.describeSubnets(any(DescribeSubnetsRequest.class)))
+				.thenReturn(DescribeSubnetsResponse.builder().subnets(generateSubnets(6)).build());
+		// dataType offered in 1a,1b,1d,1e ; masterType offered in 1a,1d,1e,1f
+		when(mockEC2.describeInstanceTypeOfferings(argThat(offeringRequestForType(dataType))))
+				.thenReturn(offeringsResponse(dataType, "us-east-1a", "us-east-1b", "us-east-1d", "us-east-1e"));
+		when(mockEC2.describeInstanceTypeOfferings(argThat(offeringRequestForType(masterType))))
+				.thenReturn(offeringsResponse(masterType, "us-east-1a", "us-east-1d", "us-east-1e", "us-east-1f"));
+		List<String> subnets = Arrays.asList("subnet1", "subnet2", "subnet3", "subnet4", "subnet5", "subnet6");
+
+		// Call under test
+		List<String> availableSubnets = ec2ClientWrapper.getAvailableSubnetsForInstanceTypes(Arrays.asList(dataType, masterType), subnets, 2);
+
+		// Intersection of AZs {1a,1d,1e} maps to subnet1, subnet4, subnet5, sorted by subnet id
+		assertEquals(Arrays.asList("subnet1", "subnet4", "subnet5"), availableSubnets);
+	}
+
+	@Test
+	void getAvailableSubnetsForInstanceTypesTooSmall() {
+		String dataType = "r6g.xlarge";
+		String masterType = "m6g.large";
+		when(mockEC2.describeSubnets(any(DescribeSubnetsRequest.class)))
+				.thenReturn(DescribeSubnetsResponse.builder().subnets(generateSubnets(6)).build());
+		// The two types share only us-east-1a, so the intersection is a single subnet.
+		when(mockEC2.describeInstanceTypeOfferings(argThat(offeringRequestForType(dataType))))
+				.thenReturn(offeringsResponse(dataType, "us-east-1a", "us-east-1b"));
+		when(mockEC2.describeInstanceTypeOfferings(argThat(offeringRequestForType(masterType))))
+				.thenReturn(offeringsResponse(masterType, "us-east-1a", "us-east-1c"));
+		List<String> subnets = Arrays.asList("subnet1", "subnet2", "subnet3", "subnet4", "subnet5", "subnet6");
+		List<String> types = Arrays.asList(dataType, masterType);
+
+		// Call under test
+		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+			ec2ClientWrapper.getAvailableSubnetsForInstanceTypes(types, subnets, 2);});
+		assertEquals(String.format("Could not find 2 available subnets for types %s in %s ", types, subnets), e.getMessage());
+	}
+
+	private static ArgumentMatcher<DescribeInstanceTypeOfferingsRequest> offeringRequestForType(String instanceType) {
+		return req -> req != null && req.filters().get(0).values().contains(instanceType);
+	}
+
+	private static DescribeInstanceTypeOfferingsResponse offeringsResponse(String instanceType, String... azs) {
+		List<InstanceTypeOffering> offerings = new ArrayList<>();
+		for (String az : azs) {
+			offerings.add(InstanceTypeOffering.builder().instanceType(instanceType).location(az).build());
+		}
+		return DescribeInstanceTypeOfferingsResponse.builder().instanceTypeOfferings(offerings).build();
 	}
 
 	/**

--- a/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
@@ -41,6 +41,9 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_VERS
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_MEMORY;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_AMAZONLINUX;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_JAVA;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ELASTICBEANSTALK_IMAGE_VERSION_TOMCAT;
@@ -349,6 +352,11 @@ public class RepositoryTemplateBuilderImplTest {
 		when(mockEc2ClientWrapper.getAvailableSubnetsForInstanceType(anyString(), any())).thenReturn(EXPECTED_SUBNETS);
 		stack = "prod";
 		configureStack(stack);
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE)).thenReturn("r6g.xlarge");
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE)).thenReturn("m6g.large");
+		when(config.getIntegerProperty(PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT)).thenReturn(2);
+		when(mockEc2ClientWrapper.getAvailableSubnetsForInstanceTypes(eq(List.of("r6g.xlarge", "m6g.large")), any(), eq(2)))
+				.thenReturn(EXPECTED_SUBNETS);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
@@ -456,8 +464,14 @@ public class RepositoryTemplateBuilderImplTest {
 		assertEquals(2, prodClusterConfig.getInt("InstanceCount"));
 		assertEquals("r6g.xlarge.search", prodClusterConfig.getString("InstanceType"));
 		assertTrue(prodClusterConfig.getBoolean("DedicatedMasterEnabled"));
+		assertEquals("m6g.large.search", prodClusterConfig.getString("DedicatedMasterType"));
 		assertEquals(3, prodClusterConfig.getInt("DedicatedMasterCount"));
 		assertTrue(prodClusterConfig.getBoolean("ZoneAwarenessEnabled"));
+		assertEquals(2, prodClusterConfig.getJSONObject("ZoneAwarenessConfig").getInt("AvailabilityZoneCount"));
+		JSONArray prodSubnetIds = prodDomainProps.getJSONObject("VPCOptions").getJSONArray("SubnetIds");
+		assertEquals(2, prodSubnetIds.length());
+		assertEquals("subnet1", prodSubnetIds.getString(0));
+		assertEquals("subnet2", prodSubnetIds.getString(1));
 		assertEquals("Retain", resources.getJSONObject("SynapseSearchIndexDomain").getString("DeletionPolicy"));
 		assertTrue(prodDomainProps.getJSONObject("SoftwareUpdateOptions").getBoolean("AutoSoftwareUpdateEnabled"));
 		assertTrue(
@@ -542,6 +556,11 @@ public class RepositoryTemplateBuilderImplTest {
 		when(mockEc2ClientWrapper.getAvailableSubnetsForInstanceType(anyString(), any())).thenReturn(EXPECTED_SUBNETS);
 		stack = "prod";
 		configureStack(stack);
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE)).thenReturn("r6g.xlarge");
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE)).thenReturn("m6g.large");
+		when(config.getIntegerProperty(PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT)).thenReturn(2);
+		when(mockEc2ClientWrapper.getAvailableSubnetsForInstanceTypes(eq(List.of("r6g.xlarge", "m6g.large")), any(), eq(2)))
+				.thenReturn(EXPECTED_SUBNETS);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
@@ -1142,6 +1161,14 @@ public class RepositoryTemplateBuilderImplTest {
 		when(config.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
 		when(config.getProperty(PROPERTY_KEY_INSTANCE)).thenReturn(instance);
 		when(config.getProperty(PROPERTY_KEY_VPC_SUBNET_COLOR)).thenReturn(vpcSubnetColor);
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_INSTANCE_TYPE)).thenReturn("r6g.xlarge");
+		when(config.getProperty(PROPERTY_KEY_OPENSEARCH_MASTER_INSTANCE_TYPE)).thenReturn("m6g.large");
+		when(config.getIntegerProperty(PROPERTY_KEY_OPENSEARCH_AVAILABILITY_ZONE_COUNT)).thenReturn(2);
+		List<String> openSearchSubnets = Arrays.asList("subnet-1a", "subnet-1c");
+		when(mockCloudFormationClientWrapper.getOutput(anyString(), anyString()))
+				.thenReturn(String.join(",", openSearchSubnets));
+		when(mockEc2ClientWrapper.getAvailableSubnetsForInstanceTypes(eq(List.of("r6g.xlarge", "m6g.large")), any(), eq(2)))
+				.thenReturn(openSearchSubnets);
 
 		when(config.getIntegerProperty(PROPERTY_KEY_REPO_RDS_ALLOCATED_STORAGE)).thenReturn(4);
 		when(config.getIntegerProperty(PROPERTY_KEY_REPO_RDS_MAX_ALLOCATED_STORAGE)).thenReturn(8);
@@ -1176,6 +1203,10 @@ public class RepositoryTemplateBuilderImplTest {
 		
 		assertEquals("Block:{}", context.get(ADMIN_RULE_ACTION));
 		assertEquals("Retain", context.get(DELETION_POLICY));
+		assertEquals("r6g.xlarge", context.get(Constants.OPENSEARCH_INSTANCE_TYPE));
+		assertEquals("m6g.large", context.get(Constants.OPENSEARCH_MASTER_INSTANCE_TYPE));
+		assertEquals(2, context.get(Constants.OPENSEARCH_AVAILABILITY_ZONE_COUNT));
+		assertEquals(openSearchSubnets, context.get(Constants.OPENSEARCH_SUBNETS));
 	}
 
 


### PR DESCRIPTION
## Problem

Creating the prod OpenSearch domain for stack-597 failed with:

> The specified instance type r6g.xlarge is not available for the AZ(s): [us-east-1b]

The domain template selected its VPC subnets positionally (the first N private subnets of the color), which always included `us-east-1b` — an AZ that does not offer the `r6g.xlarge` data node type (nor the `m6g.large` dedicated master type).

## Change

The subnets are now chosen dynamically: the builder looks up, via the EC2 instance-type offerings API, the availability zones that offer **both** the data and dedicated master instance types, and attaches the domain only to subnets in those AZs. The instance types and AZ count are configuration values.