### PR TITLE
[PLFM-9782] Allow Developer SSO role to administer non-prod shared-resources CMK

### DIFF
--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -1013,6 +1013,7 @@
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_6620166dd0e7f1b6" }
                                         #else
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Administrator_693a85eb20cd5043" },
+                                        { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Developer_1513da6c8161f765" },
                                         { "Fn::Sub": "arn:aws:iam::#[[${AWS::AccountId}]]#:role/Synapse-Build-${instance}-CodeBuildServiceRole" }
                                         #end
                                     ]


### PR DESCRIPTION
## Summary
Developers can't fully delete their personal sandbox stacks in synapsedev — after granting the Developer SSO role scoped IAM delete permissions (organizations-infra), `kms:DeleteAlias` on the shared-resources CMK still fails with `AccessDenied`.

The cause is this template's CMK **key policy**: an explicit `Deny kms:* Principal:*` gated by a `StringNotLike aws:PrincipalArn` allowlist. Only root, the deployment/build roles, and the **Administrator** SSO role are allowlisted — the **Developer** SSO role is not. An explicit key-policy Deny overrides any identity-based Allow, so this can only be fixed here.

This adds the Developer SSO role ARN to the **non-prod** (`#else`) branch of the allowlist, alongside the existing non-prod Administrator entry. Prod (`#if($stack == 'prod')`) is intentionally left unchanged.

Jira: https://sagebionetworks.jira.com/browse/PLFM-9782

## Security note
This grants the Developer role full `kms:*` (CMK admin, incl. `ScheduleKeyDeletion`) on **all non-prod Synapse stacks** (dev/staging), not only personal sandboxes, since the `#else` branch covers every non-prod instance. Requesting reviewer sign-off on that tradeoff.

## Notes
- Uses the same hardcoded permission-set suffix convention as the existing Administrator entry (`AWSReservedSSO_Developer_1513da6c8161f765`).
- This is build-time templating, so it only affects **newly built** stacks. Stacks already stuck in `DELETE_FAILED` carry the old key policy and must be cleared using the Administrator role.

## Test plan
- [x] `mvn test -Dtest=RepositoryTemplateBuilderImplTest` — 27/27 pass (template renders + parses)
- [ ] Reviewer confirms rendered non-prod CMK key policy includes the Developer ARN and prod does not