### PR TITLE
SAGL-90: Add bucket for lambda artifacts

### DIFF
--- a/src/main/resources/templates/s3/s3-buckets-config.json
+++ b/src/main/resources/templates/s3/s3-buckets-config.json
@@ -80,7 +80,11 @@
 		},
 		{
 			"name": "${stack}.grid.snapshot.sagebase.org"
+		},
+		{
+			"name": "${stack}.artifacts.sagebase.org"
 		}
+
 	],
 	"inventoryConfig": {
 		"bucket": "${stack}.datawarehouse.sagebase.org",


### PR DESCRIPTION
This PR adds a bucket to each stack to store artifacts (in this case, markdown-it-vx.y.z.zip released on Github and copied before deployment).