### PR TITLE
PLFM-9704: Add SEARCH_INDEX_SOURCE_UPDATE and SEARCH_INDEX_REBUILD queues

### DIFF
--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -32,7 +32,8 @@
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
 		"GRID_REPLICA_CHANGES",
-		"GRID_SESSION"
+		"GRID_SESSION",
+		"SEARCH_INDEX_REBUILD"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -554,6 +555,22 @@
 			],
 			"messageVisibilityTimeoutSec": 120,
 			"oldestMessageInQueueAlarmThresholdSec": 30
+		},
+		{
+			"queueName": "SEARCH_INDEX_SOURCE_UPDATE",
+			"subscribedTopicNames": [
+				"TABLE_STATUS_EVENT"
+			],
+			"messageVisibilityTimeoutSec": 60,
+			"messageRetentionPeriodSec": 1209600
+		},
+		{
+			"queueName": "SEARCH_INDEX_REBUILD",
+			"subscribedTopicNames": [
+				"SEARCH_INDEX_REBUILD"
+			],
+			"messageVisibilityTimeoutSec": 60,
+			"deadLetterQueueMaxFailureCount": 5
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Adds the two SQS queues (and one SNS topic) that the SearchIndex source-availability / live-sync rebuild flow requires. The repository worker code already references these queue names via `stackConfig.getQueueName(...)`, but the queues did not exist in this config — without them the workers fail to resolve their queue URLs at runtime.

## Changes (`templates/repo/sns-and-sqs-config.json`)

- **`SEARCH_INDEX_SOURCE_UPDATE`** queue — hop-1 worker (`SearchIndexSourceUpdateWorker`) subscribes to `TABLE_STATUS_EVENT` to detect a source table/view becoming available. Mirrors `MATERIALIZED_VIEW_SOURCE_UPDATE`, including the 14-day retention.
- **`SEARCH_INDEX_REBUILD`** topic + queue — hop-2 worker (`SearchIndexRebuildWorker`) consumes rebuild requests fired via `fireLocalStackMessage(ObjectType.SEARCH_INDEX_REBUILD)`. That `ObjectType` is published to an SNS topic of the same name, so the topic is added to `snsTopicNames` and the queue subscribes to it (DLQ after 5 failures, matching `SEARCH_INDEX_LIFECYCLE`).

The managed OpenSearch domain template needs no change: the blue-green alias-swap uses index/alias operations already covered by the domain's `es:ESHttp*` access policy, and cluster/VPC/encryption/EBS sizing are unaffected.

## Testing

`SnsAndSqsConfigTest` and `RepositoryTemplateBuilderImplTest` pass (30 tests), including the invariant that every `subscribedTopicNames` entry exists in `snsTopicNames`.