### PR TITLE
Update CLAUDE.md files to reflect codebase evolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ mvn test -Dtest=S3ConfigValidatorTest#testValidate # Run a single test method
 
 CI runs `mvn --batch-mode clean test` on PRs to `develop` and `release-*` branches.
 
+The build toolchain targets **Java 11** (`pom.xml` compiler source/target). This is distinct from the **deployed** platform image, which is **Java 21 / Tomcat 10** (`repo-defaults.properties`). Do not "align" the pom to 21 — the two versions are intentionally different.
+
 ## Architecture
 
 Synapse Stack Builder is a Java application that generates and deploys AWS CloudFormation stacks for the Synapse research platform. The core pipeline is:
@@ -22,7 +24,7 @@ Synapse Stack Builder is a Java application that generates and deploys AWS Cloud
 ### Key Patterns
 
 - **Guice DI**: `TemplateGuiceModule` is the central wiring point — all builders, AWS clients, config objects, and Velocity engine are bound here.
-- **Velocity templates**: `.vtp` files in `src/main/resources/templates/` are merged with context to produce CloudFormation JSON. The Velocity engine loads templates from both classpath and filesystem.
+- **Velocity templates**: `.vpt` files in `src/main/resources/templates/` are merged with context to produce CloudFormation JSON. The Velocity engine loads templates from both classpath and filesystem.
 - **VelocityContextProvider**: Pluggable interface (registered via Guice Multibinder) that contributes variables to template contexts. This is the main extensibility point — new resource types add a provider implementation and bind it in the module.
 - **Descriptor/Builder pattern**: Resources are defined as descriptor objects (e.g., `EnvironmentDescriptor`, `S3BucketDescriptor`) with builder-style methods, then transformed into CloudFormation resources via templates.
 - **Configuration-driven**: JSON config files (`src/main/resources/templates/`) define S3 buckets, SNS/SQS queues, Kinesis streams, AppConfig, Athena queries, etc. These are deserialized into typed config objects and validated by corresponding `*Validator` classes.
@@ -33,18 +35,18 @@ Stacks are deployed in dependency order:
 1. **Global Resources** — KMS keys, IAM roles, helper Lambdas
 2. **VPC** — Network infrastructure, subnets by color (red/blue/green/orange for AZs)
 3. **Shared Resources** — RDS databases, encryption, secrets
-4. **Environment Stacks** — Elastic Beanstalk environments (repo services, workers, tables, migration)
+4. **Environment Stacks** — repo services, workers, tables, migration environments. Each deploys to either **Elastic Beanstalk** or **ECS Fargate**, selected by the `PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS` property (`DeploymentTarget` enum). `RepositoryTemplateBuilderImpl.buildEnvironments()` branches into `buildBeanstalkEnvironments()` or `buildEcsEnvironments()`. See `src/main/java/org/sagebionetworks/template/repo/ecs/CLAUDE.md` for the Fargate path (Docker build → ECR).
 5. **CDN & Network** — CloudFront distributions, Network Load Balancers
 
 ### Entry Points
 
-Multiple `*Main` classes each build a specific stack type: `RepositoryBuilderMain`, `VpcBuilderMain`, `S3BuilderMain`, `CdnBuilderMain`, `DataWarehouseBuilderMain`, `GlobalResourcesBuilderMain`, etc.
+Multiple `*Main` classes each build a specific stack type: `RepositoryBuilderMain`, `VpcBuilderMain`, `S3BuilderMain`, `CdnBuilderMain`, `DataWarehouseBuilderMain`, `GlobalResourcesBuilderMain`, etc. `RepositoryBuilderMain` is cross-cutting: it builds S3 buckets (`S3BucketBuilder.buildAllBuckets()`) and deploys docs before building the environment stacks.
 
 ## Main Packages (`org.sagebionetworks.template`)
 
 | Package | Purpose |
 |---------|---------|
-| `repo/` | Repository/Elastic Beanstalk infrastructure (sub-packages: `appconfig/`, `beanstalk/`, `kinesis/`, `queues/`, `cloudwatchlogs/`, `glue/`, `athena/`, `agent/`) |
+| `repo/` | Repository environment infrastructure (sub-packages: `appconfig/`, `beanstalk/`, `ecs/`, `kinesis/`, `queues/`, `cloudwatchlogs/`, `glue/`, `athena/`, `agent/`, `grid/`) |
 | `s3/` | S3 bucket configuration and building |
 | `vpc/` | VPC and subnet templates |
 | `cdn/` | CloudFront CDN resources |
@@ -52,6 +54,13 @@ Multiple `*Main` classes each build a specific stack type: `RepositoryBuilderMai
 | `global/` | Account-level global AWS resources |
 | `ip/` | IP address pool management |
 | `config/` | Configuration management |
+| `cron/` | Scheduled stack teardown / TTL jobs |
+| `docs/` | Synapse docs builder |
+| `jobs/` | Async admin job executor |
+| `markdownit/` | markdown-it Lambda |
+| `nlb/` | Network load balancer builder |
+| `redirectors/` | User-docs redirector |
+| `utils/` | Artifact download helpers |
 
 ## Testing
 
@@ -68,4 +77,16 @@ public class FooTest {
 }
 ```
 
-Test files follow `*Test.java` naming. Integration tests use `*IntegrationTest.java`.
+Test files follow `*Test.java` naming. Integration tests use `*IntegrationTest.java`. `RepositoryTemplateBuilderImplTest` is the standard place to assert rendered template shape (prod vs dev) for new resource types.
+
+## Conventions
+
+- **AWS SDK v2 for new code.** New/edited AWS client code uses `software.amazon.awssdk` v2 clients (e.g. `S3Client`, `PutObjectRequest`, `RequestBody`). A v1→v2 migration is in progress, so both are bound in `TemplateGuiceModule` today — do not add new `com.amazonaws...AmazonS3Client` (v1) usage.
+- **Adding simple buckets/queues is config-only.** New S3 buckets and SNS/SQS queues are added via config entries (`s3/s3-buckets-config.json`, `repo/sns-and-sqs-config.json`); no Java/builder changes needed for a plain bucket or queue.
+
+## Anti-Patterns — Do NOT
+
+- **Do NOT select multi-AZ subnets positionally / by fixed index** for resources with AZ-specific instance-type constraints (e.g. OpenSearch `VpcOptions.SubnetIds`) — query which AZs support the instance type (EC2 `DescribeInstanceTypeOfferings`) and derive subnet/AZ counts from config. Positional selection silently picks AZs lacking the type and breaks prod (PLFM-9788, PR #901).
+- **Do NOT add a service reached over a VPC endpoint (e.g. a new Bedrock service) in `repo/agent` or `repo/grid` without also updating the VPC endpoint list** — see `src/main/java/org/sagebionetworks/template/vpc/CLAUDE.md`; environments silently lose connectivity otherwise.
+- **Do NOT create AWS resources dynamically from a Lambda without a CloudFormation Custom Resource to clean them up** — CFN has no knowledge of out-of-band resources, so they accumulate across stack teardown/rebuild (PR #896).
+- **Do NOT assume an IAM identity-based Allow grants KMS access** — an explicit `Deny kms:* Principal:*` in a CMK key policy overrides it; granting a new role requires updating the key-policy allowlist itself, and prod vs non-prod branches must be updated separately (PLFM-9782, PR #903).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,16 @@ Test files follow `*Test.java` naming. Integration tests use `*IntegrationTest.j
 
 - **AWS SDK v2 for new code.** New/edited AWS client code uses `software.amazon.awssdk` v2 clients (e.g. `S3Client`, `PutObjectRequest`, `RequestBody`). A v1→v2 migration is in progress, so both are bound in `TemplateGuiceModule` today — do not add new `com.amazonaws...AmazonS3Client` (v1) usage.
 - **Adding simple buckets/queues is config-only.** New S3 buckets and SNS/SQS queues are added via config entries (`s3/s3-buckets-config.json`, `repo/sns-and-sqs-config.json`); no Java/builder changes needed for a plain bucket or queue.
+- **Two config interfaces — inject the right one.** `RepoConfigurationImpl` auto-loads `templates/repo/repo-defaults.properties` on construction; plain `ConfigurationImpl` loads no defaults. Guice binds them to `RepoConfiguration` vs `Configuration`; repo-scoped builders need `RepoConfiguration` or required defaults are silently absent.
+- **`SnsAndSqsConfig` deserializes with Jackson, not GSON** (its class comment says "GSON" but the annotations are `@JsonCreator`/`@JsonProperty`). Don't "fix" the annotations to match the comment. Queue FIFO-ness is inferred purely from a `.fifo` suffix on the queue name.
+- **`repo/athena` recurrent queries** require their `destinationQueue` to exist in `SnsAndSqsConfig`, and default their query database to the firehose `GLUE_DB_SUFFIX` constant; the query string is loaded from a file under `athena/` and re-evaluated as a Velocity template.
+- **`repo/cloudwatchlogs` config** requires exactly 2 `LogDescriptor`s per `EnvironmentType`, all environment types present, and no duplicate `LogType` — the validator throws otherwise.
+- **`docs/` deploys via a custom ETag-diff S3 sync**, gated by a `docs-stack-instance.json` marker with an `instance` counter (only syncs when the configured instance is newer). Do not replace it with a plain `s3 sync`-style copy — it would break the idempotency/versioning gate.
+
+## Subsystem guides
+
+Deeper, package-local conventions live in child `CLAUDE.md` files — read the relevant one before working in that area:
+`template/` (top-level — CFN client wrapper & Guice module gotchas), `repo/`, `repo/beanstalk/`, `repo/ecs/`, `repo/agent/`, `repo/grid/`, `repo/kinesis/firehose/`, `s3/`, `vpc/`, `cdn/`, `nlb/`, `global/`, `datawarehouse/`.
 
 ## Anti-Patterns — Do NOT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Synapse Stack Builder is a Java application that generates and deploys AWS Cloud
 ### Key Patterns
 
 - **Guice DI**: `TemplateGuiceModule` is the central wiring point — all builders, AWS clients, config objects, and Velocity engine are bound here.
-- **Velocity templates**: `.vpt` files in `src/main/resources/templates/` are merged with context to produce CloudFormation JSON. The Velocity engine loads templates from both classpath and filesystem.
+- **Velocity templates**: Template files in `src/main/resources/templates/` are merged with context to produce CloudFormation JSON. Both `.vpt` (most templates) and `.vtp` (vpc, cdn, markdownit, redirectors) extensions are in use — there is no functional difference; each is loaded by its literal path, so match whatever extension the sibling files in a package already use. The Velocity engine loads templates from both classpath and filesystem.
 - **VelocityContextProvider**: Pluggable interface (registered via Guice Multibinder) that contributes variables to template contexts. This is the main extensibility point — new resource types add a provider implementation and bind it in the module.
 - **Descriptor/Builder pattern**: Resources are defined as descriptor objects (e.g., `EnvironmentDescriptor`, `S3BucketDescriptor`) with builder-style methods, then transformed into CloudFormation resources via templates.
 - **Configuration-driven**: JSON config files (`src/main/resources/templates/`) define S3 buckets, SNS/SQS queues, Kinesis streams, AppConfig, Athena queries, etc. These are deserialized into typed config objects and validated by corresponding `*Validator` classes.

--- a/src/main/java/org/sagebionetworks/template/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — `template` (top-level)
+
+Shared infrastructure used by every builder: the Guice module, the CloudFormation client wrapper, AWS client wrappers, and `Constants`. Sub-packages own specific resource types.
+
+## `CloudFormationClientWrapperImpl` — do not "clean up" these
+
+- **Templates are never sent inline.** `createStack`/`updateStack` upload the template body to S3 first (`executeWithS3Template` → `saveTemplateToS3`, a `templates/<stack>-<uuid>.json` object) and delete it in a `finally` regardless of outcome. Preserve the upload-then-delete flow.
+- **`waitForStackToComplete` has deliberate `switch` fallthrough** (no `break`): `CREATE_IN_PROGRESS`/`UPDATE_IN_PROGRESS` call `handleWaitConditions` then fall through into the sleep/log case; `UPDATE_ROLLBACK_COMPLETE` falls through to the `default` throw **unless** the stack started in that state (idempotency guard `startedInUpdateRollbackComplete`). Adding `break`s here changes behavior — don't.
+- **"No updates are to be performed" is string-matched** and treated as non-fatal (`NO_UPDATES_ARE_TO_BE_PERFORMED`). Keep this — CFN signals a no-op update via exception.
+- **`describeStack` swallows all `CloudFormationException`s as "stack does not exist"** (returns `Optional.empty()`), conflating a missing stack with an API error. This is existing, deliberate-for-now behavior (its own `// TODO: can this case happen?`). Flag rather than silently "fix".
+
+## `TemplateGuiceModule` conventions
+
+- **Two Multibinder extension points**, both bound here: `Multibinder<VelocityContextProvider>` (contributes template context vars — the main extension point the root CLAUDE.md documents) and `Multibinder<WaitConditionHandler>` (post-deploy CFN wait-condition handlers — see `global/CLAUDE.md`). A new provider/handler is registered by adding a binding here.
+- **Region is hardcoded `Region.US_EAST_1`** on ~15 AWS client providers. New client providers should match.
+- Cross-account "image-central" access uses a one-off STS `AssumeRoleRequest` / `StsAssumeRoleCredentialsProvider` provider — reuse this pattern if another cross-account client is ever needed.

--- a/src/main/java/org/sagebionetworks/template/cdn/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/cdn/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md — `cdn` (incl. `webacl`)
+
+Builds CloudFront distributions. `CdnBuilderImpl` handles two distribution types (`Type.PORTAL`, `Type.DATA`); `webacl/CdnWebAclBuilderImpl` is a simpler template-only builder with no notable gotchas.
+
+## Conventions
+
+- **The CDN reuses the portal Beanstalk's ACM certificate.** `createContext` reads `PROPERTY_KEY_BEANSTALK_SSL_ARN + "portal"` for the CDN's ACM ARN (comment: "The ACM ARN is the same as the one used for portal"). Non-obvious cross-resource reuse — don't create a separate cert.
+- **`Type` (PORTAL/DATA) drives duplicated if/else branches** in both `createContext` and `buildCdnStack`, each with a matching `IllegalArgumentException` guard. If a third `Type` is added, update both branch sites in sync.
+- **The DATA CDN hashes its public key with MD5** (`DigestUtils.md5Hex`) for a template context variable — this is a cache-key/identifier use, not security; leave it as MD5 to match the template.

--- a/src/main/java/org/sagebionetworks/template/datawarehouse/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/datawarehouse/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md — `datawarehouse` (incl. `backfill`)
+
+Deploys the Glue/Athena data-warehouse ETL infrastructure. `DataWarehouseBuilderImpl` builds the stack; `backfill/BackfillDataWarehouseBuilderImpl` runs one-off Glue backfill jobs over historical S3 partitions.
+
+## Conventions
+
+- **`copyArtifactFromGithub` downloads a GitHub release zip and re-uploads matched entries to S3.** It wraps the shared `ZipInputStream` with `ReleasableInputStream.wrap(...).disableClose()` so the S3 SDK does not close the stream mid-loop. Preserve the `disableClose()` — without it the upload closes the zip stream and subsequent entries fail.
+- **The GitHub download pattern and the hardcoded AWS Glue Studio transform URLs** (`gs_explode.py`, `gs_common.py` under bucket `aws-glue-studio-transforms-510798373988-prod-us-east-1`) are **duplicated** in both `DataWarehouseBuilderImpl` and `backfill/BackfillDataWarehouseBuilderImpl`. Keep the two copies in sync if either changes.
+
+## backfill/ constraints
+
+- **`githubRepo` / `version` are hardcoded** (`"Synapse-ETL-Jobs"`, `"1.39.0"`) in `BackfillDataWarehouseBuilderImpl`, whereas the parent `DataWarehouseBuilderImpl` reads both from `DataWarehouseConfig`. This divergence is intentional (the backfill pins a specific job version) — do NOT "deduplicate" them into shared config.
+- **Athena query completion is polled with an unbounded `Thread.sleep(5000)` loop** (no timeout/retry cap), plus a `Thread.sleep(2000)` throttle after each Glue job start. If you touch this, be aware there is no upper bound.
+- **Glue partition params are reconstructed by a recursive S3-prefix walk** using fragile `indexOf`/substring parsing tied to hardcoded folder names. Changing the S3 layout breaks the parsing.

--- a/src/main/java/org/sagebionetworks/template/global/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/global/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md — `global` (incl. `waitconditions`)
+
+Builds account-level global resources (KMS, IAM, Cognito, SES, Bedrock knowledge base). `GlobalResourcesBuilderImpl` deploys the CFN stack, then does imperative AWS-API post-processing that CloudFormation cannot express.
+
+## Post-CFN imperative steps (`GlobalResourcesBuilderImpl`)
+
+- **Cognito → Secrets Manager copy.** After the stack completes, `copyCognitoSecretsToSecretsManager` reads the Cognito app client id/secret via the Cognito API and writes them to Secrets Manager under `{stackPrefix}.{KEY}` (also stores the OIDC discovery-doc URL). `setSecret` is create-or-`putSecretValue` idempotent. Do not move this into the CFN template — CFN can't retrieve the app secret.
+- **SES topic wiring is prod-only** — gated by `"prod".equalsIgnoreCase(stack)` (a raw string compare, not `Constants.isProd`). Match the existing check if you add similar prod-gating here.
+
+## WaitConditionHandler (`waitconditions/`)
+
+`WaitConditionHandler` implementations are a **second Guice `Multibinder` extension point** (parallel to `VelocityContextProvider`), bound in `TemplateGuiceModule`.
+
+- **Each handler is matched to a CFN template resource by exact string** via `getWaitConditionId()` — it must equal the wait-condition logical id in the `.vpt` template, or the handler never fires.
+- **Handlers must be idempotent** — they are invoked repeatedly while the outer stack poll runs (e.g. `SynapseHelpKnowledgeBaseDataSourceSync` returns early if an ingestion job already exists).
+- **`SynapseHelpKnowledgeBaseDataSourceSync.handle()` runs its own blocking `Thread.sleep(10s)` poll loop** *inside* the outer `CloudFormationClientWrapperImpl.waitForStackToComplete` loop. This nested blocking counts against the outer wait timeout — keep handler work bounded.

--- a/src/main/java/org/sagebionetworks/template/nlb/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/nlb/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md — `nlb`
+
+Builds Network Load Balancers and binds them to the repo services. Two builders with deliberately different behavior.
+
+## Constraints
+
+- **The two builders diverge on stack waiting — do NOT harmonize them.** `NetworkLoadBalancerBuilderImpl.buildAndDeploy()` does **not** call `waitForStackToComplete` (fire-and-forget); `BindNetworkLoadBalancerBuilderImpl.buildAndDeploy()` **does** wait. They share JSON-reformat/stack-name boilerplate but the wait difference is intentional — unifying them changes deployment behavior.
+- **`NetworkLoadBalancer` reuses the cross-package static `IpAddressPoolBuilderImpl.ipAddressName(shortName, az)`** (in `ip/address`) to reconstruct Elastic-IP allocation names that must match the EIP pool stack. There is no compiler-visible link — if you change the `"%sAZ%d"` naming format in `ip/address`, NLB↔EIP association breaks.
+- **`RecordToStackMapping.validateTarget` enforces a strict 4-part hyphen target format** (`{portal|repo}-{prod|dev}-###-#`) via `EnvironmentType`. Silent format changes elsewhere break this validation.

--- a/src/main/java/org/sagebionetworks/template/repo/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md — `repo`
+
+Orchestrates the repository environment stacks. `RepositoryTemplateBuilderImpl` is the central builder: it creates shared resources (RDS, secrets), then builds the per-environment stacks (repo services, workers, tables, migration). Sub-packages own individual resource types (`beanstalk/`, `ecs/`, `athena/`, `kinesis/`, `queues/`, `cloudwatchlogs/`, `appconfig/`, `glue/`, `agent/`, `grid/`).
+
+## Deployment target branch
+
+`buildEnvironments()` reads `PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS` (`DeploymentTarget` enum) and branches into `buildBeanstalkEnvironments()` or `buildEcsEnvironments()`. The two paths differ in build AND wait behavior — Beanstalk builds/waits per stack in the loop; ECS submits all stacks then waits. Do not "unify" them without preserving each path's ordering. See `ecs/CLAUDE.md` for the Fargate image build.
+
+## Constraints
+
+- **NOSNAPSHOT invariant** (`createDatabaseDescriptors`): the repo DB and the table DBs must agree on whether they use RDS snapshots. If one uses the `NOSNAPSHOT` sentinel and the other doesn't, it throws `IllegalStateException`. When editing snapshot-identifier properties, keep repo and tables consistent.
+- **`TargetGroup` naming is a cross-site contract.** `new TargetGroup(type, stack, instance, number)` produces a name that **must match** the convention used by `dns-record-to-stack-mapping` and by `beanstalk/ssl/ElasticBeanstalkExtentionBuilderImpl`. Changing the format requires updating every construction site (comment marks this at the ALB target-group export).
+- **CFN outputs are parsed by string-splitting** — when consuming a stack output, match the existing brittle parsing rather than assuming structured access.
+
+## Related
+
+- Snapshot/secret/CMK naming (`alias/synapse/<stack>/<instance>/cmk`, master secret `<stack>.<key>`, secrets S3 key `Stack/<stack>-<instance>-secrets.properties`) is shared by `beanstalk/SecretBuilderImpl` and `IdGeneratorBuilderImpl` — see `beanstalk/CLAUDE.md`.

--- a/src/main/java/org/sagebionetworks/template/repo/agent/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/agent/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md — `repo/agent`
+
+Contributes the Bedrock Agent CloudFormation resources to the Velocity context (`BedrockAgentContextProvider`, `BedrockGridAgentContextProvider`). Unlike other providers, the CFN is NOT authored in a `.vpt` template — it is loaded from a static JSON template (`bedrock_agent_template.json`) and mutated in Java via raw `org.json` `JSONObject`/`JSONArray` path-navigation, then spliced into the Velocity context.
+
+## Constraints
+
+- **Do NOT edit the shared JSON template's external portions directly.** `bedrock_agent_template.json` is shared with external people, so Sage-specific values are patched in Java (e.g. replacing knowledge-base ARNs/IDs with `Fn::ImportValue` references). The comment in `addToContext` marks this. Add substitutions in Java, not by editing the shared template.
+- **Do NOT reformat the JSON string surgery.** The result is inserted via `context.put(..., "," + json.substring(1, json.length()-1))` — it strips the outer `{}` and prepends a comma so it merges into a surrounding object literal in the `.vpt`. Reformatting or reindenting this breaks the CFN merge.
+- **Building the context has an S3 side effect.** `addToContext` uploads the OpenAPI action-group schema (`agent_open_api.json`) to `{stack}-configuration.sagebase.org` via `S3Client.putObject`. This I/O happens during context assembly, not deployment — non-obvious for a context provider.
+
+The `JSONArray`/`JSONObject` index paths (e.g. `Policies[0]/PolicyDocument/Statement[n]`, `KnowledgeBases/Fn::If[1][0]`) are tightly coupled to the shared template's structure; if that template changes shape, these indices must be updated in lockstep.

--- a/src/main/java/org/sagebionetworks/template/repo/beanstalk/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/beanstalk/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md — `repo/beanstalk` (incl. `beanstalk/ssl`)
+
+Builds the Elastic Beanstalk deployment artifacts: downloads the app WAR from Artifactory, injects `.ebextensions`, uploads to S3, and generates the TLS material. `ssl/` is tightly coupled to this package (WAR bundling + cert generation) — treat them as one unit.
+
+## Conventions
+
+- **`ArtifactCopyImpl` is an idempotent cache.** `copyArtifactIfNeeded` guards on `s3Client.doesObjectExist(bucket, s3Key)` and only downloads from Artifactory + re-bundles the WAR when the S3 object is missing. Do not remove the existence check — it avoids re-downloading on every deploy.
+- **`EnvironmentType` gates secrets.** Only `REPOSITORY_SERVICES` and `REPOSITORY_WORKERS` include secrets (`shouldIncludeSecrets()` / the `includeSecrets` flag); `PORTAL` does not. Code that wires secrets must respect this — don't assume every environment gets them.
+- **`getShortName()` returns the `cnamePrefix`** (`repo`, `workers`, `portal`), not the enum name. Artifactory URL and S3 key use `pathName` (`services-repository`, etc.). These are distinct strings — use the right accessor.
+
+## Constraints
+
+- **Naming formats are load-bearing — do not change casually:**
+  - `TargetGroup` name (`type-stack-instance-number`, dash-stripped for the short form) must match `dns-record-to-stack-mapping` and the ALB target-group export in `repo/RepositoryTemplateBuilderImpl` (two construction sites).
+  - CMK alias `alias/synapse/<stack>/<instance>/cmk`, master secret key `<stack>.<key>`, and secrets S3 key `Stack/<stack>-<instance>-secrets.properties` are relied on by both `SecretBuilderImpl` and `repo/IdGeneratorBuilderImpl`.
+- **`ElasticBeanstalkExtentionBuilderImpl.copyWarWithExtensions` has a strict ordered bundling pipeline** with ~9 hardcoded `.ebextensions` template paths. Do not reorder or rename the directory/file creation without checking every path constant stays consistent.
+- **The X.509 cert is regenerated on every WAR build**, not cached (`CertificateBuilderImpl`: self-signed, RSA 2048, fixed DN, 1-year validity). Do not assume a stable cert across deploys.

--- a/src/main/java/org/sagebionetworks/template/repo/ecs/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/ecs/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md — `repo/ecs`
+
+ECS Fargate deployment target for repository environments, an alternative to Elastic Beanstalk (selected by `PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS`). Unlike the rest of the codebase, this package does NOT go through the Velocity → CloudFormation pipeline for the image: `DockerImageBuilderImpl` builds a Docker image locally and pushes it to ECR, then `ecs-fargate-template.json.vpt` references the resulting image URI.
+
+## Flow
+
+`buildAndPushImage()`: download WAR from Artifactory → render a build context (Dockerfile, server.xml, startup.sh, nginx.conf from `.vpt` templates + a self-signed TLS cert) → `docker buildx build` → `aws ecr` login → `docker push`. Returns the image URI consumed by the Fargate template.
+
+## Constraints
+
+- **Docker build MUST stay `docker buildx build --platform linux/arm64`** — the Fargate task definition declares `runtimePlatform` ARM64 regardless of the build host's architecture (`DockerImageBuilderImpl.dockerBuild`). Changing the platform produces an image the task cannot run.
+- **Docker / `aws sts` / `aws ecr` are invoked by shelling out** via `ProcessBuilder` (`sh -c` for piped commands), not the Java AWS SDK. This is deliberate — since Docker itself must be shelled out to, switching just ECR auth to a Java client adds complexity without removing the CLI dependency (comment in `ecrLogin`). The AWS CLI and Docker with buildx must be present on the build host.
+- **Region is hardcoded `us-east-1`.** Image URI format is `{account}.dkr.ecr.{region}.amazonaws.com/{ecrRepoName}:{tag}`; tag is `{stack}-{instance}-{version}-{number}`; ECR repo name is `{stack}-synapse-{shortName}` (`getEcrRepositoryName`). The ECR repositories themselves are created by `global/ecr-repositories.json.vpt`.
+- **Temp WAR file and build-context dir are deleted in `finally`** (`buildAndPushImage`) — preserve this cleanup when editing.
+
+## Gotcha
+
+- `EcsEnvironmentDescriptor.getType()` returns `type.getShortName()`, **not** the enum name. Use `getEnvironmentType()` to get the `EnvironmentType` enum. Do not "fix" `getType()` to return the enum name — templates depend on the short name.

--- a/src/main/java/org/sagebionetworks/template/repo/grid/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/grid/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md — `repo/grid`
+
+`GridContextProvider` contributes the grid websocket API Gateway resources to the Velocity context.
+
+## Gotchas
+
+- **`context.put("D", "$")`** exposes `$D` in the `.vpt` templates as a literal `$`. Use `$D` for dollar signs in the websocket request/response mapping JSON rather than fighting Velocity's `$`-variable escaping.
+- **Fragments are loaded via `loadFileRemoveLineBreaks`** (`connect-request-template.vpt`, `default-request-template.vpt`, `disconnect-request-template.vpt`, `access-logs-setting-format.vpt`), which strips all line breaks (`\R+`). API Gateway mapping templates must be single-line, so keep these fragments free of anything that depends on line breaks.
+- Grid depends on Bedrock VPC endpoints — see the VPC endpoint sync note in `src/main/java/org/sagebionetworks/template/vpc/CLAUDE.md` if you add a new Bedrock-backed service here.

--- a/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/repo/kinesis/firehose/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md — `repo/kinesis/firehose`
+
+Builds Kinesis Firehose delivery streams that land records in S3 (optionally converting JSON → Parquet via a Glue table). `KinesisFirehoseVelocityContextProvider` post-processes the configured streams before rendering.
+
+## Conventions
+
+- **`devOnly` streams are dropped only on the prod stack.** `addToContext` filters out `stream.isDevOnly()` streams when the stack equals `Constants.PROD_STACK_NAME`; on all other stacks they deploy. Preserve this filter when editing stream selection.
+- **Glue database name is derived, not configured.** It is `stack + instance + GLUE_DB_SUFFIX` where `GLUE_DB_SUFFIX = "firehoseLogs"`. This constant is imported cross-package by `repo/athena` as its default query database — changing it affects Athena queries too.
+- **Stream bucket and table names are parameterized** — bucket via `TemplateUtils.replaceStackVariable(...)`, table name via `stack + instance + name`. New streams should follow this, not hardcode names.
+
+## Validation (`KinesisFirehoseConfigValidator`)
+
+- `bufferFlushInterval` and `bufferFlushSize` are clamped to hardcoded MIN/MAX constants on `KinesisFirehoseStreamDescriptor`; out-of-range values throw `IllegalStateException`.
+- **PARQUET format requires a non-null `tableDescriptor` with ≥1 column**; JSON does not. Adding a Parquet stream without a table definition fails validation.

--- a/src/main/java/org/sagebionetworks/template/s3/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/s3/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md — `s3`
+
+S3 buckets are configured **imperatively via the AWS SDK**, not declared in CloudFormation/Velocity like the rest of the codebase. `S3BucketBuilderImpl.buildAllBuckets()` reads `s3-buckets-config.json` and, for each bucket, does get-then-set idempotency: fetch current state, create/update only what differs (encryption, public-access-block, inventory, lifecycle rules, intelligent-tiering, notifications).
+
+## Conventions
+
+- **Adding a bucket is config-only** — add an entry to `s3/s3-buckets-config.json`; no Java changes needed for a plain bucket.
+- **Reuse the generic `addOrUpdateRule(rules, bucket, ruleName, definition, ruleCreator, ruleUpdate)` helper** for lifecycle rules (retention, class-transition, abort-multipart) rather than writing bespoke rule diffing.
+- **`createBucket` treats `BucketAlreadyOwnedByYou` (409) as non-fatal/idempotent** so a re-run continues past already-owned buckets (PLFM-9661). Do not "fix" this by re-throwing.
+
+## Constraints
+
+- **Do NOT convert the S3 → virus-scanner notification wiring to pure CloudFormation.** Bucket notifications for the scanner topic are set imperatively (`configureBucketNotification`) *after* the virus-scanner stack is built and its topic ARN is available, because CFN cannot express this without a circular dependency (comment cites cloudformation-coverage-roadmap issue #79). The imperative wiring across multiple buckets is a deliberate simpler alternative to the AWS custom-resource workaround.

--- a/src/main/java/org/sagebionetworks/template/vpc/CLAUDE.md
+++ b/src/main/java/org/sagebionetworks/template/vpc/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md — `vpc`
+
+VPC and subnet CloudFormation templates. Subnets are grouped by color (red/blue/green/orange) mapping to AZs; `SubnetTemplateBuilderImpl` builds public and per-color private subnet stacks.
+
+## Constraints
+
+- **`SubnetTemplateBuilderImpl.VPC_ENDPOINT_SERVICES` hardcodes the Bedrock VPC endpoints** (`bedrock, bedrock-agent, bedrock-runtime, bedrock-agent-runtime`), fed to every subnet group. When `repo/agent` or `repo/grid` starts depending on a new Bedrock (or other AWS) service reached over a VPC endpoint, add it to this list — otherwise those environments silently lose connectivity to the new service.


### PR DESCRIPTION
The root `CLAUDE.md` was last updated 2026-03-23; 89 commits have landed since, adding architecture the doc didn't reflect. It was also the *only* CLAUDE.md in the repo, despite most `template/` sub-packages having distinct sub-architectures with real gotchas.

This PR audits and corrects the root file, and adds child `CLAUDE.md` files across the tree so package-local conventions live where they apply (altitude rule) rather than bloating the root. All specific claims were verified directly against source. Docs-only; no code changes.

## Root `CLAUDE.md`
- Fix template extension `.vtp` → `.vpt`
- Document the dual **Beanstalk / ECS Fargate** deployment target (was Beanstalk-only)
- Complete the Main Packages table (`ecs/`, `grid/` sub-packages + 7 missing top-level packages)
- Clarify **Java 11 build toolchain vs Java 21 / Tomcat 10 deployed image**
- Note `RepositoryBuilderMain` also builds S3 buckets + docs
- Conventions: AWS SDK v2 direction, config-only bucket/queue additions, `Configuration` vs `RepoConfiguration`, Jackson-not-GSON in `SnsAndSqsConfig`, `athena`/`cloudwatchlogs` validator rules, `docs/` ETag-diff sync
- Anti-Patterns: positional AZ selection, Lambda-created resources without a custom resource, KMS key-policy `Deny`, VPC endpoint sync
- A "Subsystem guides" index pointing to the child files

## New child `CLAUDE.md` files
Each documents package-local conventions an agent working only from the root would get wrong:
- **`template/`** (top-level) — `CloudFormationClientWrapperImpl` deliberate `switch` fallthrough, S3-upload-then-delete template flow, `describeStack` error conflation; two Guice `Multibinder` extension points; hardcoded `US_EAST_1`
- **`repo/`** — NOSNAPSHOT invariant, `TargetGroup` cross-site naming contract, dual build+wait paths
- **`repo/beanstalk/`** (+`ssl/`) — `ArtifactCopy` idempotent cache, `EnvironmentType` secrets gating, 9 hardcoded ebextension paths, per-build cert, load-bearing naming formats
- **`repo/ecs/`** — ARM64 build requirement, deliberate shell-out design, ECR naming/URI format, `getType()`→shortName trap
- **`repo/agent/`** — shared JSON template patched in Java, substring-splice fragility, S3 side effect during context assembly
- **`repo/grid/`** — `$D` dollar-sign escaping, single-line mapping-template fragments
- **`repo/kinesis/firehose/`** — devOnly prod filtering, buffer clamps, PARQUET table requirement, `GLUE_DB_SUFFIX` shared with `athena/`
- **`s3/`** — imperative SDK config, `addOrUpdateRule` helper, CFN/S3-notification circular-dependency workaround
- **`vpc/`** — hardcoded Bedrock VPC endpoint list that must stay in sync with `repo/agent` and `repo/grid`
- **`cdn/`** (+`webacl/`) — portal ACM cert reuse, PORTAL/DATA branch sync, MD5 key hash
- **`nlb/`** — builders diverge on `waitForStackToComplete`, cross-package `ipAddressName` reuse, strict 4-part target format
- **`global/`** (+`waitconditions/`) — imperative Cognito→SecretsManager copy, `WaitConditionHandler` string-matched id + idempotency + nested poll loop
- **`datawarehouse/`** (+`backfill/`) — `ReleasableInputStream.disableClose`, duplicated github/glue-script logic, intentional hardcoded-vs-config version divergence