### PR TITLE
PLFM-9797: Fix per error in console

### DIFF
--- a/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
+++ b/src/main/resources/templates/repo/main-repo-shared-resources-template.json.vpt
@@ -791,12 +791,12 @@
                         },
                         {
                             "Action": [
-                                "bedrockagentcore:InvokeCodeInterpreter",
-                                "bedrockagentcore:ListCodeInterpreters"
+                                "bedrock-agentcore:InvokeCodeInterpreter",
+                                "bedrock-agentcore:ListCodeInterpreters"
                             ],
                             "Resource": [
                                 {
-                                  "Fn::Sub": "arn:aws:bedrockagentcore:#[[${AWS::Region}:${AWS::AccountId}]]#:code-interpreter/*"
+                                  "Fn::Sub": "arn:aws:bedrock-agentcore:#[[${AWS::Region}:${AWS::AccountId}]]#:code-interpreter-custom/*"
                                 }
                             ],
                             "Effect": "Allow"


### PR DESCRIPTION
This PR should address the stack failing to start on release-598.
Verified by manually modifying the policy and restarting the Beanstalk environments.