### PR TITLE
SAGL: markdownit v2

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -110,8 +110,13 @@ public class Constants {
 	public static final String PROPERTY_KEY_RDS_REPO_SNAPSHOT_IDENTIFIER = "org.sagebionetworks.repo.snapshot.identifier";
 	public static final String PROPERTY_KEY_RDS_TABLES_SNAPSHOT_IDENTIFIERS = "org.sagebionetworks.tables.snapshot.identifiers";
 	public static final String PROPERTY_KEY_LAMBDA_VIRUS_SCANNER_ARTIFACT_URL = "org.sagebionetworks.lambda.virusscanner.artifactUrl";
-	public static final String PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL = "org.sagebionetworks.lambda.markdownit.artifactUrl";
 	public static final String PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET = "org.sagebionetworks.lambda.artifact.bucket";
+
+	public static final String PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL = "org.sagebionetworks.lambda.markdownit.artifactUrl";
+	public static final String PROPERTY_KEY_LAMBDA_MARKDOWN_IT_SUBDOMAIN = "org.sagebionetworks.lambda.markdownit.subdomain";
+	public static final String PROPERTY_KEY_LAMBDA_MARKDOWNIT_VERSION = "org.sagebionetworks.lambda.markdownit.version";
+	public static final String PROPERTY_KEY_LAMBDA_MARKDOWNIT_CERTIFICATE_ARN = "org.sagebionetworks.lambda.markdownit.cerificatearn";
+
 	public static final String NOSNAPSHOT = "NOSNAPSHOT"; // value to indicate a snapshot is not used to init a stack
 
 	public static final String PROPERTY_KEY_ENABLE_RDS_ENHANCED_MONITORING = "org.sagebionetworks.enable.rds.enhanced.monitoring";
@@ -168,7 +173,7 @@ public class Constants {
 	public static final String TEMPLATE_DATAWAREHOUSE = "templates/datawarehouse/datawarehouse-template.json.vpt";
 	public static final String TEMPLATE_S3_BUCKET_POLICY = "templates/s3/s3-bucket-policy.json.vpt";
 
-	public static final String TEMPLATE_MARKDOWNIT_API_VTP = "templates/markdownit/markdown-it-api.json.vtp";
+	public static final String TEMPLATE_MARKDOWNIT_API_VTP = "templates/markdownit/synapse-markdownit-lambda-infra.json.vtp";
 
 	public static final int JSON_INDENT = 5;
 

--- a/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
+++ b/src/main/java/org/sagebionetworks/template/TemplateGuiceModule.java
@@ -14,6 +14,7 @@ import static org.sagebionetworks.template.TemplateUtils.loadFromJsonFile;
 import java.io.IOException;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
@@ -259,8 +260,15 @@ public class TemplateGuiceModule extends com.google.inject.AbstractModule {
 
  	@Provides
 	public HttpClient provideHttpClient() {
-		HttpClientBuilder builder = HttpClientBuilder.create();
-		return builder.build();
+		RequestConfig requestConfig = RequestConfig.custom()
+				.setConnectTimeout(30_000)
+				.setSocketTimeout(60_000)
+				.setConnectionRequestTimeout(30_000)
+				.build();
+		return HttpClientBuilder.create()
+				.useSystemProperties()
+				.setDefaultRequestConfig(requestConfig)
+				.build();
 	}
 	
 	@Provides

--- a/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
@@ -21,10 +21,7 @@ import java.io.File;
 import java.io.StringWriter;
 import java.util.Optional;
 
-import static org.sagebionetworks.template.Constants.CAPABILITY_NAMED_IAM;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
+import static org.sagebionetworks.template.Constants.*;
 
 public class MarkDownItLambdaBuilderImpl implements MarkDownItLambdaBuilder {
 
@@ -60,30 +57,48 @@ public class MarkDownItLambdaBuilderImpl implements MarkDownItLambdaBuilder {
     public void buildMarkDownItLambda() {
 
         String stack = config.getProperty(PROPERTY_KEY_STACK);
-        String artifactBucket = config.getProperty(PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET);
-        String lambdaSourceArtifactUrl = config.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL);
-        String lambdaArtifactKey = String.format("artifacts/markdown-it/%s", FilenameUtils.getName(lambdaSourceArtifactUrl));
+        String artifactBucket = String.format("%s.artifacts.sagebase.org", stack);
+        String markdownitVersion = config.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_VERSION);
+        String markdownitArtifactUrl = markdownitArtifactUrlFromVersion(markdownitVersion);
+        String lambdaArtifactKey = markdownitArtifactKeyFromVersion(markdownitVersion);
+        String markdownitSubDomain = config.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWN_IT_SUBDOMAIN);
+        // Should cover *.[dev|prod].sagebase.org
+        String certificateArn = config.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_CERTIFICATE_ARN);
 
-        // Download from jfrog and upload to S3
-        File artifact = downloader.downloadFile(lambdaSourceArtifactUrl);
+        // copy artifact to S3
+        File artifact = downloader.downloadFile(markdownitArtifactUrl);
         try {
             s3Client.putObject(artifactBucket, lambdaArtifactKey, artifact);
         } finally {
             artifact.delete();
         }
 
-        buildMarkDownItLambdaStack(stack, artifactBucket, lambdaArtifactKey);
+        buildMarkDownItLambdaStack(stack, lambdaArtifactKey, markdownitSubDomain, certificateArn);
 
     }
 
-    private Optional<Stack> buildMarkDownItLambdaStack(String stack, String artifactBucket, String artifactKey) {
+    static String markdownitArtifactKeyFromVersion(String version) {
+        return String.format("markdown-it-%s.zip", version);
+    }
+    static String markdownitArtifactUrlFromVersion(String version) {
+        final String urfFormat = "https://github.com/Sage-Bionetworks/synapse-markdown-it-lambda/releases/download/%s/%s";
+        return String.format(urfFormat, version, markdownitArtifactKeyFromVersion(version));
+    }
+
+    private Optional<Stack> buildMarkDownItLambdaStack(
+            String stack,
+            String artifactKey,
+            String markdownitSubdomain,
+            String certificateArn) {
 
         String stackName = String.format("%s-markdown-it-function", stack);
 
         // Setup context
         VelocityContext context = new VelocityContext();
-        context.put("lambdaArtifactBucket", artifactBucket);
+        context.put("stack", stack);
         context.put("lambdaArtifactKey", artifactKey);
+        context.put("markdownitSubDomain", markdownitSubdomain);
+        context.put("certificateArn", certificateArn);
 
         // Generate template
         Template template = velocityEngine.getTemplate(Constants.TEMPLATE_MARKDOWNIT_API_VTP);

--- a/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImpl.java
@@ -89,8 +89,8 @@ public class MarkDownItLambdaBuilderImpl implements MarkDownItLambdaBuilder {
         return String.format("markdown-it-%s.zip", version);
     }
     static String markdownitArtifactUrlFromVersion(String version) {
-        final String urfFormat = "https://github.com/Sage-Bionetworks/synapse-markdown-it-lambda/releases/download/%s/%s";
-        return String.format(urfFormat, version, markdownitArtifactKeyFromVersion(version));
+        final String urlfFormat = "https://sagebionetworks.jfrog.io/artifactory/lambda-artifacts/org/sagebionetworks/markdown-it/%s";
+        return String.format(urlfFormat, markdownitArtifactKeyFromVersion(version));
     }
 
     private Optional<Stack> buildMarkDownItLambdaStack(

--- a/src/main/resources/templates/markdownit/synapse-markdownit-lambda-infra.json.vtp
+++ b/src/main/resources/templates/markdownit/synapse-markdownit-lambda-infra.json.vtp
@@ -1,0 +1,142 @@
+{
+  "Resources": {
+    "mdlambdaServiceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Service": "lambda.amazonaws.com" },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "LambdaBasicExecutionRole",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": [
+                    { "Fn::Sub": "arn:aws:logs:#[[${AWS::Region}:${AWS::AccountId}]]#:log-group:/aws/lambda/*" }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "mdlambda": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "${stack}.artifacts.sagebase.org",
+          "S3Key": "${lambdaArtifactKey}"
+        },
+        "Handler": "index.handler",
+        "Role": { "Fn::GetAtt": [ "mdlambdaServiceRole", "Arn" ] },
+        "Runtime": "nodejs24.x",
+        "Timeout": 10
+      }
+    },
+    "mdlambdaLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Retain",
+      "Properties": {
+        "LogGroupName": { "Fn::Sub": "/aws/lambda/#[[${mdlambda}]]#" },
+        "RetentionInDays": 731
+      }
+    },
+    "MarkdownItApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "MarkdownItApi"
+      }
+    },
+    "MarkdownItApiPostMethod": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "AuthorizationType": "AWS_IAM",
+        "HttpMethod": "POST",
+        "ResourceId": { "Fn::GetAtt": [ "MarkdownItApi", "RootResourceId" ] },
+        "RestApiId": { "Ref": "MarkdownItApi" },
+        "Integration": {
+          "Type": "AWS_PROXY",
+          "IntegrationHttpMethod": "POST",
+          "Uri": {
+            "Fn::Sub": "arn:aws:apigateway:#[[${AWS::Region}]]#:lambda:path/2015-03-31/functions/#[[${mdlambda.Arn}]]#/invocations"
+          }
+        }
+      }
+    },
+    "MarkdownItApiPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "DependsOn": ["MarkdownItApiPostMethod"],
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": { "Fn::GetAtt": [ "mdlambda", "Arn" ] },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Sub": "arn:#[[${AWS::Partition}]]#:execute-api:#[[${AWS::Region}]]#:#[[${AWS::AccountId}]]#:#[[${MarkdownItApi}]]#/*/POST/"
+        }
+      }
+    },
+    "MarkdownItApiDeployment": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "DependsOn": ["MarkdownItApiPostMethod"],
+      "Properties": {
+        "RestApiId": { "Ref": "MarkdownItApi" },
+        "Description": "Deployment for the markdown-it API"
+      }
+    },
+    "MarkdownItApiStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": { "Ref": "MarkdownItApi" },
+        "DeploymentId": { "Ref": "MarkdownItApiDeployment" },
+        "StageName": "prod"
+      }
+    },
+    "CustomDomain": {
+      "Type": "AWS::ApiGateway::DomainName",
+      "Properties": {
+        "DomainName": "${markdownitSubDomain}.${stack}.sagebase.org",
+        "EndpointConfiguration": { "Types": ["REGIONAL"] },
+        "RegionalCertificateArn": "${certificateArn}"
+      }
+    },
+    "BasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping",
+      "Properties": {
+        "BasePath": "md2html",
+        "DomainName": { "Ref": "CustomDomain" },
+        "RestApiId": { "Ref": "MarkdownItApi" },
+        "Stage": { "Ref": "MarkdownItApiStage" }
+      }
+    }
+  },
+  "Outputs": {
+    "ApiGatewayUrl": {
+      "Description": "The API Gateway endpoint for the markdown-it Lambda function",
+      "Value": {
+        "Fn::Sub": "https://#[[${MarkdownItApi}]]#.execute-api.#[[${AWS::Region}]]#.#[[${AWS::URLSuffix}]]#/#[[${MarkdownItApiStage}]]#/"
+      }
+    },
+    "CustomDomainAlias": {
+      "Description": "Create a CNAME record pointing your custom domain to this value",
+      "Value": { "Fn::GetAtt": [ "CustomDomain", "RegionalDomainName" ] }
+    }
+  }
+}

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -21,7 +21,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -29,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.sagebionetworks.template.Constants.*;
-import static org.sagebionetworks.template.markdownit.MarkDownItLambdaBuilderImpl.markdownitArtifactKeyFromVersion;
 
 @ExtendWith(MockitoExtension.class)
 public class MarkDownItLambdaBuilderImplTest {
@@ -65,6 +63,7 @@ public class MarkDownItLambdaBuilderImplTest {
     @Test
     public void testBuildMarkDownItLambda() throws Exception {
 
+        testFile = File.createTempFile("markdown-it-v0.0.1", "zip");
         velocityEngine = new TemplateGuiceModule().velocityEngineProvider();
 
         MarkDownItLambdaBuilder builder = new MarkDownItLambdaBuilderImpl(
@@ -91,7 +90,6 @@ public class MarkDownItLambdaBuilderImplTest {
         builder.buildMarkDownItLambda();
 
         verify(mockDownloader).downloadFile("https://github.com/Sage-Bionetworks/synapse-markdown-it-lambda/releases/download/v0.0.1/markdown-it-v0.0.1.zip");
-        verify(mockS3Client).putObject(expectedBucket, expectedKey, mockFile);
 
         ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
         ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -53,8 +53,6 @@ public class MarkDownItLambdaBuilderImplTest {
 
     @BeforeEach
     public void before() throws Exception {
-        stack = "dev";
-        when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
         when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_VERSION)).thenReturn("v0.0.1");
         when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWN_IT_SUBDOMAIN)).thenReturn("md2html");
         when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_CERTIFICATE_ARN)).thenReturn("arn:123456789012:cert");
@@ -62,6 +60,8 @@ public class MarkDownItLambdaBuilderImplTest {
 
     @Test
     public void testBuildMarkDownItLambda() throws Exception {
+        stack = "dev";
+        when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
 
         testFile = File.createTempFile("markdown-it-v0.0.1", "zip");
         velocityEngine = new TemplateGuiceModule().velocityEngineProvider();
@@ -89,7 +89,7 @@ public class MarkDownItLambdaBuilderImplTest {
         // call under test
         builder.buildMarkDownItLambda();
 
-        verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdown-it-v0.0.1.zip");
+        verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/artifactory/lambda-artifacts/org/sagebionetworks/markdown-it/markdown-it-v0.0.1.zip");
 
         ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
         ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
@@ -134,4 +134,79 @@ public class MarkDownItLambdaBuilderImplTest {
 
     }
 
+    @Test
+    public void testBuildProdMarkDownItLambda() throws Exception {
+        stack = "prod";
+        when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
+
+        testFile = File.createTempFile("markdown-it-v0.0.1", "zip");
+        velocityEngine = new TemplateGuiceModule().velocityEngineProvider();
+
+        MarkDownItLambdaBuilder builder = new MarkDownItLambdaBuilderImpl(
+                mockConfig,
+                mockDownloader,
+                mockCloudFormationClientWrapper,
+                mockTagsProvider,
+                mockS3Client,
+                velocityEngine);
+
+
+        when(mockDownloader.downloadFile(any())).thenReturn(testFile);
+
+        when(mockTagsProvider.getStackTags(mockConfig)).thenReturn(Collections.emptyList());
+
+        Stack markdownItLambdaStack = Stack.builder().build();
+
+        when(mockCloudFormationClientWrapper.describeStack(any())).thenReturn(Optional.of(markdownItLambdaStack));
+
+        String expectedBucket = "prod.artifacts.sagebase.org";
+        String expectedKey = "markdown-it-v0.0.1.zip";
+
+        // call under test
+        builder.buildMarkDownItLambda();
+
+        verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/artifactory/lambda-artifacts/org/sagebionetworks/markdown-it/markdown-it-v0.0.1.zip");
+
+        ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);
+        verify(mockS3Client).putObject(putRequestCaptor.capture(), requestBodyCaptor.capture());
+        assertNotNull(requestBodyCaptor.getValue());
+        PutObjectRequest capturedRequest = putRequestCaptor.getValue();
+        assertEquals(expectedBucket, capturedRequest.bucket());
+        assertEquals(expectedKey, capturedRequest.key());
+
+        ArgumentCaptor<CreateOrUpdateStackRequest> argCaptorCreateOrUpdateStack = ArgumentCaptor.forClass(CreateOrUpdateStackRequest.class);
+        ArgumentCaptor<String> argCaptorWaitForStack = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> argCaptorDescribeStack = ArgumentCaptor.forClass(String.class);
+
+        verify(mockCloudFormationClientWrapper, times(1)).createOrUpdateStack(argCaptorCreateOrUpdateStack.capture());
+        verify(mockCloudFormationClientWrapper, times(1)).waitForStackToComplete(argCaptorWaitForStack.capture());
+        verify(mockCloudFormationClientWrapper, times(1)).describeStack(argCaptorDescribeStack.capture());
+
+        CreateOrUpdateStackRequest request = argCaptorCreateOrUpdateStack.getValue();
+        assertEquals("prod-markdown-it-function", request.getStackName());
+        assertTrue(request.getTags().isEmpty());
+        assertEquals(1, request.getCapabilities().length);
+        assertEquals(Capability.CAPABILITY_NAMED_IAM, request.getCapabilities()[0]);
+        assertNotNull(request.getTemplateBody());
+
+        JSONObject templateJson = new JSONObject(request.getTemplateBody());
+        System.out.println(request.getTemplateBody());
+        JSONObject resources = templateJson.getJSONObject("Resources");
+        assertTrue(resources.has("mdlambdaServiceRole"));
+        assertTrue(resources.has("mdlambda"));
+        assertTrue(resources.has("MarkdownItApi"));
+        assertTrue(resources.has("MarkdownItApiPostMethod"));
+        assertTrue(resources.has("MarkdownItApiPermission"));
+        assertTrue(resources.has("MarkdownItApiDeployment"));
+        assertTrue(resources.has("MarkdownItApiStage"));
+        assertTrue(resources.has("CustomDomain"));
+        assertTrue(resources.has("BasePathMapping"));
+
+        assertEquals("prod-markdown-it-function", argCaptorWaitForStack.getValue());
+        assertEquals("prod-markdown-it-function", argCaptorDescribeStack.getValue());
+
+        assertFalse(testFile.exists());
+
+    }
 }

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -89,7 +89,7 @@ public class MarkDownItLambdaBuilderImplTest {
         // call under test
         builder.buildMarkDownItLambda();
 
-        verify(mockDownloader).downloadFile("https://github.com/Sage-Bionetworks/synapse-markdown-it-lambda/releases/download/v0.0.1/markdown-it-v0.0.1.zip");
+        verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdown-it-v0.0.1.zip");
 
         ArgumentCaptor<PutObjectRequest> putRequestCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
         ArgumentCaptor<RequestBody> requestBodyCaptor = ArgumentCaptor.forClass(RequestBody.class);

--- a/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/markdownit/MarkDownItLambdaBuilderImplTest.java
@@ -26,13 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.sagebionetworks.template.Constants.CAPABILITY_NAMED_IAM;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL;
-import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
+import static org.mockito.Mockito.*;
+import static org.sagebionetworks.template.Constants.*;
+import static org.sagebionetworks.template.markdownit.MarkDownItLambdaBuilderImpl.markdownitArtifactKeyFromVersion;
 
 @ExtendWith(MockitoExtension.class)
 public class MarkDownItLambdaBuilderImplTest {
@@ -63,8 +59,9 @@ public class MarkDownItLambdaBuilderImplTest {
     public void before() {
         stack = "dev";
         when(mockConfig.getProperty(PROPERTY_KEY_STACK)).thenReturn(stack);
-        when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_ARTIFACT_BUCKET)).thenReturn("lambda.sagebase.org");
-        when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_ARTIFACT_URL)).thenReturn("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdownit.zip");
+        when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_VERSION)).thenReturn("v0.0.1");
+        when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWN_IT_SUBDOMAIN)).thenReturn("md2html");
+        when(mockConfig.getProperty(PROPERTY_KEY_LAMBDA_MARKDOWNIT_CERTIFICATE_ARN)).thenReturn("arn:123456789012:cert");
     }
 
     @Test
@@ -89,13 +86,13 @@ public class MarkDownItLambdaBuilderImplTest {
 
         when(mockCloudFormationClientWrapper.describeStack(any())).thenReturn(Optional.of(markdownItLambdaStack));
 
-        String expectedBucket = "lambda.sagebase.org";
-        String expectedKey = "artifacts/markdown-it/markdownit.zip";
+        String expectedBucket = "dev.artifacts.sagebase.org";
+        String expectedKey = "markdown-it-v0.0.1.zip";
 
         // call under test
         builder.buildMarkDownItLambda();
 
-        verify(mockDownloader).downloadFile("https://sagebionetworks.jfrog.io/lambda/org/sagebase/markdownit/markdownit.zip");
+        verify(mockDownloader).downloadFile("https://github.com/Sage-Bionetworks/synapse-markdown-it-lambda/releases/download/v0.0.1/markdown-it-v0.0.1.zip");
         verify(mockS3Client).putObject(expectedBucket, expectedKey, mockFile);
 
         verify(mockFile).delete();
@@ -120,7 +117,13 @@ public class MarkDownItLambdaBuilderImplTest {
         JSONObject resources = templateJson.getJSONObject("Resources");
         assertTrue(resources.has("mdlambdaServiceRole"));
         assertTrue(resources.has("mdlambda"));
-        assertTrue(resources.has("mdlambdaFunctionUrl"));
+        assertTrue(resources.has("MarkdownItApi"));
+        assertTrue(resources.has("MarkdownItApiPostMethod"));
+        assertTrue(resources.has("MarkdownItApiPermission"));
+        assertTrue(resources.has("MarkdownItApiDeployment"));
+        assertTrue(resources.has("MarkdownItApiStage"));
+        assertTrue(resources.has("CustomDomain"));
+        assertTrue(resources.has("BasePathMapping"));
 
         assertEquals("dev-markdown-it-function", argCaptorWaitForStack.getValue());
         assertEquals("dev-markdown-it-function", argCaptorDescribeStack.getValue());


### PR DESCRIPTION
This PR updates the way markdownit lambda is deployed:
- new endpoint (md2html.<stack>.sagebase.org)
- version the artifact
- setup API with signing