### PR TITLE
PLFM-9704: Generalize source-update queue and add SEARCH_INDEX_REBUILD

### DIFF
--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -23,6 +23,7 @@
 		"JSON_SCHEMA_DEPENDANT",
 		"THREAD_VIEW",
 		"MATERIALIZED_VIEW",
+		"SOURCE_DEPENDENCY_EVENT",
 		"RECORDSET",
 		"TABLE_STATUS_EVENT",
 		"DATA_ACCESS_SUBMISSION_EVENT",
@@ -32,8 +33,7 @@
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
 		"GRID_REPLICA_CHANGES",
-		"GRID_SESSION",
-		"SEARCH_INDEX_REBUILD"
+		"GRID_SESSION"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -361,7 +361,8 @@
 		{
 			"queueName": "MATERIALIZED_VIEW_UPDATE",
 			"subscribedTopicNames": [
-				"MATERIALIZED_VIEW"
+				"MATERIALIZED_VIEW",
+				"SOURCE_DEPENDENCY_EVENT"
 			],
 			"messageVisibilityTimeoutSec": 120,
 			"messageRetentionPeriodSec": 1209600
@@ -552,7 +553,7 @@
 		{
 			"queueName": "SEARCH_INDEX_REBUILD",
 			"subscribedTopicNames": [
-				"SEARCH_INDEX_REBUILD"
+				"SOURCE_DEPENDENCY_EVENT"
 			],
 			"messageVisibilityTimeoutSec": 60,
 			"messageRetentionPeriodSec": 1209600

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -23,7 +23,7 @@
 		"JSON_SCHEMA_DEPENDANT",
 		"THREAD_VIEW",
 		"MATERIALIZED_VIEW",
-		"SOURCE_DEPENDENCY_EVENT",
+		"SEARCH_INDEX",
 		"RECORDSET",
 		"TABLE_STATUS_EVENT",
 		"DATA_ACCESS_SUBMISSION_EVENT",
@@ -33,7 +33,8 @@
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
 		"GRID_REPLICA_CHANGES",
-		"GRID_SESSION"
+		"GRID_SESSION",
+		"SOURCE_DEPENDENCY_EVENT"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -545,18 +546,12 @@
 		{
 			"queueName": "SEARCH_INDEX_LIFECYCLE",
 			"subscribedTopicNames": [
-				"ENTITY"
+				"ENTITY",
+				"SEARCH_INDEX",
+				"SOURCE_DEPENDENCY_EVENT"
 			],
 			"messageVisibilityTimeoutSec": 300,
 			"deadLetterQueueMaxFailureCount": 5
-		},
-		{
-			"queueName": "SEARCH_INDEX_REBUILD",
-			"subscribedTopicNames": [
-				"SOURCE_DEPENDENCY_EVENT"
-			],
-			"messageVisibilityTimeoutSec": 60,
-			"messageRetentionPeriodSec": 1209600
 		},
 		{
 			"queueName": "SEARCH_QUERY",

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -32,7 +32,8 @@
 		"PROJECT_STORAGE_EVENT",
 		"REPLICATED_EVENT",
 		"GRID_REPLICA_CHANGES",
-		"GRID_SESSION"
+		"GRID_SESSION",
+		"SEARCH_INDEX_REBUILD"
 	],
 	"snsGlobalTopicNames": [
 		"SES_SYNAPSE_ORG_BOUNCE",
@@ -374,7 +375,7 @@
 			"messageRetentionPeriodSec": 1209600
 		},
 		{
-			"queueName": "MATERIALIZED_VIEW_SOURCE_UPDATE",
+			"queueName": "DEFINING_SQL_SOURCE_UPDATE",
 			"subscribedTopicNames": [
 				"TABLE_STATUS_EVENT"
 			],
@@ -547,6 +548,14 @@
 			],
 			"messageVisibilityTimeoutSec": 300,
 			"deadLetterQueueMaxFailureCount": 5
+		},
+		{
+			"queueName": "SEARCH_INDEX_REBUILD",
+			"subscribedTopicNames": [
+				"SEARCH_INDEX_REBUILD"
+			],
+			"messageVisibilityTimeoutSec": 60,
+			"messageRetentionPeriodSec": 1209600
 		},
 		{
 			"queueName": "SEARCH_QUERY",

--- a/src/main/resources/templates/repo/sns-and-sqs-config.json
+++ b/src/main/resources/templates/repo/sns-and-sqs-config.json
@@ -23,7 +23,6 @@
 		"JSON_SCHEMA_DEPENDANT",
 		"THREAD_VIEW",
 		"MATERIALIZED_VIEW",
-		"SEARCH_INDEX",
 		"RECORDSET",
 		"TABLE_STATUS_EVENT",
 		"DATA_ACCESS_SUBMISSION_EVENT",
@@ -547,7 +546,6 @@
 			"queueName": "SEARCH_INDEX_LIFECYCLE",
 			"subscribedTopicNames": [
 				"ENTITY",
-				"SEARCH_INDEX",
 				"SOURCE_DEPENDENCY_EVENT"
 			],
 			"messageVisibilityTimeoutSec": 300,


### PR DESCRIPTION
## Summary

Supports generalizing the materialized-view source-dependency pattern into a shared **defining-SQL dependency** pattern (materialized views + search indexes) in Synapse-Repository-Services.

Changes to `templates/repo/sns-and-sqs-config.json`:

- **Rename** queue `MATERIALIZED_VIEW_SOURCE_UPDATE` → `DEFINING_SQL_SOURCE_UPDATE`. A single worker now consumes this queue and fans out to both materialized views and search indexes, each doing its own type-filtered reverse lookup against the shared dependency table.
- **Add** SNS topic `SEARCH_INDEX_REBUILD` and queue `SEARCH_INDEX_REBUILD` (subscribes the topic) for the per-index rebuild hop.

Both queues subscribe as before (`DEFINING_SQL_SOURCE_UPDATE` → `TABLE_STATUS_EVENT`); the rebuild queue is fed by the new topic that the repo publishes per dependent search index.

## Notes

- This supersedes the reverted #905, which had introduced a separate `SEARCH_INDEX_SOURCE_UPDATE` queue. The collapse to one generalized source-update queue removes the need for that second queue.
- Paired with the repo-side change that renames the DAO/DBO/tables and merges the two source-update workers into one `DefiningSqlSourceUpdateWorker`.