### PR TITLE
PLFM-8873: Migrate to AWS SDK v2

### DIFF
--- a/src/main/java/org/sagebionetworks/template/CloudFormationClientWrapperImpl.java
+++ b/src/main/java/org/sagebionetworks/template/CloudFormationClientWrapperImpl.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.template;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -22,11 +20,9 @@ import org.apache.logging.log4j.Logger;
 import org.sagebionetworks.template.config.Configuration;
 import org.sagebionetworks.template.repo.beanstalk.SourceBundle;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.inject.Inject;
 
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
 import software.amazon.awssdk.services.cloudformation.model.CreateStackRequest;
@@ -44,6 +40,9 @@ import software.amazon.awssdk.services.cloudformation.model.StackStatus;
 import software.amazon.awssdk.services.cloudformation.model.UpdateStackRequest;
 import software.amazon.awssdk.services.cloudformation.model.UpdateStackResponse;
 import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 /**
  * Basic implementation CloudFormationClient
@@ -59,14 +58,14 @@ public class CloudFormationClientWrapperImpl implements CloudFormationClientWrap
 	public static final String NO_UPDATES_ARE_TO_BE_PERFORMED = "No updates are to be performed";
 	
 	private final CloudFormationClient cloudFormationClient;
-	private final AmazonS3 s3Client;
+	private final S3Client s3Client;
 	private final Configuration configuration;
 	private final Logger logger;
 	private final ThreadProvider threadProvider;
 	private final Map<String, WaitConditionHandler> waitConditionHandlerMap;
 	
 	@Inject
-	public CloudFormationClientWrapperImpl(CloudFormationClient cloudFormationClient, AmazonS3 s3Client,
+	public CloudFormationClientWrapperImpl(CloudFormationClient cloudFormationClient, S3Client s3Client,
 										   Configuration configuration, LoggerFactory loggerFactory, ThreadProvider threadProvider, Set<WaitConditionHandler> waitConditionHandlers) {
 		super();
 		this.cloudFormationClient = cloudFormationClient;
@@ -213,18 +212,11 @@ public class CloudFormationClientWrapperImpl implements CloudFormationClientWrap
 	 * @return
 	 */
 	SourceBundle saveTemplateToS3(String stackName, String template) {
-		try {
-			String bucket = configuration.getConfigurationBucket();
-			String key = "templates/" + stackName + "-" + UUID.randomUUID() + ".json";
-			byte[] bytes = template.getBytes("UTF-8");
-			ByteArrayInputStream input = new ByteArrayInputStream(bytes);
-			ObjectMetadata metadata = new ObjectMetadata();
-			metadata.setContentLength(bytes.length);
-			s3Client.putObject(new PutObjectRequest(bucket, key, input, metadata));
-			return new SourceBundle(bucket, key);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
+		String bucket = configuration.getConfigurationBucket();
+		String key = "templates/" + stackName + "-" + UUID.randomUUID() + ".json";
+		s3Client.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
+				RequestBody.fromString(template));
+		return new SourceBundle(bucket, key);
 	}
 
 	/**
@@ -243,7 +235,7 @@ public class CloudFormationClientWrapperImpl implements CloudFormationClientWrap
 	 * @param bundle
 	 */
 	void deleteTemplate(SourceBundle bundle) {
-		s3Client.deleteObject(bundle.getBucket(), bundle.getKey());
+		s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bundle.getBucket()).key(bundle.getKey()).build());
 	}
 
 	public boolean isStartedInUpdateRollbackComplete(String stackName) {

--- a/src/main/java/org/sagebionetworks/template/datawarehouse/DataWarehouseBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/datawarehouse/DataWarehouseBuilderImpl.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.template.datawarehouse;
 
-import com.amazonaws.internal.ReleasableInputStream;
-import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.Inject;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.Template;
@@ -17,7 +15,10 @@ import org.sagebionetworks.template.config.Configuration;
 import org.sagebionetworks.template.repo.VelocityExceptionThrower;
 import org.sagebionetworks.template.utils.ArtifactDownload;
 import org.sagebionetworks.util.ValidateArgument;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.cloudformation.model.Capability;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,12 +56,12 @@ public class DataWarehouseBuilderImpl implements DataWarehouseBuilder {
     private StackTagsProvider tagsProvider;
     private DataWarehouseConfig dataWarehouseConfig;
     private ArtifactDownload downloader;
-    private AmazonS3 s3Client;
+    private S3Client s3Client;
 
     @Inject
     public DataWarehouseBuilderImpl(CloudFormationClientWrapper cloudFormationClientWrapper, VelocityEngine velocityEngine,
                                     Configuration config, LoggerFactory loggerFactory,
-                                    StackTagsProvider tagsProvider, DataWarehouseConfig dataWarehouseConfig, ArtifactDownload downloader, AmazonS3 s3Client) {
+                                    StackTagsProvider tagsProvider, DataWarehouseConfig dataWarehouseConfig, ArtifactDownload downloader, S3Client s3Client) {
         this.cloudFormationClientWrapper = cloudFormationClientWrapper;
         this.velocityEngine = velocityEngine;
         this.config = config;
@@ -143,8 +144,9 @@ public class DataWarehouseBuilderImpl implements DataWarehouseBuilder {
 					String scriptFile = entry.getName();
 					String s3Key = s3ScriptsPath + scriptFile.replace(scriptPath, "");
 					logger.info("Uploading " + scriptFile + " to " + s3Key);
-					// Uses a stream with close disabled so that the s3 sdk does not close it for us
-					s3Client.putObject(bucket, s3Key, ReleasableInputStream.wrap(zipInputStream).disableClose(), null);
+					// Read the current zip entry into memory so the upload does not close the shared zip stream
+					byte[] bytes = zipInputStream.readAllBytes();
+					s3Client.putObject(PutObjectRequest.builder().bucket(bucket).key(s3Key).build(), RequestBody.fromBytes(bytes));
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/org/sagebionetworks/template/datawarehouse/backfill/BackfillDataWarehouseBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/datawarehouse/backfill/BackfillDataWarehouseBuilderImpl.java
@@ -1,9 +1,5 @@
 package org.sagebionetworks.template.datawarehouse.backfill;
 
-import com.amazonaws.internal.ReleasableInputStream;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.logging.log4j.Logger;
@@ -20,6 +16,7 @@ import org.sagebionetworks.template.datawarehouse.DataWarehouseBuilderImpl;
 import org.sagebionetworks.template.repo.VelocityExceptionThrower;
 import org.sagebionetworks.template.utils.ArtifactDownload;
 import org.sagebionetworks.util.ValidateArgument;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.Datum;
 import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
@@ -40,6 +37,11 @@ import software.amazon.awssdk.services.glue.model.GetTableResponse;
 import software.amazon.awssdk.services.glue.model.PartitionInput;
 import software.amazon.awssdk.services.glue.model.StartJobRunRequest;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CommonPrefix;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.File;
 import java.io.IOException;
@@ -88,7 +90,7 @@ public class BackfillDataWarehouseBuilderImpl implements BackfillDataWarehouseBu
     private Configuration config;
     private Logger logger;
     private VelocityEngine velocityEngine;
-    private AmazonS3 s3Client;
+    private S3Client s3Client;
     private CloudFormationClientWrapper cloudFormationClientWrapper;
     private StackTagsProvider tagsProvider;
     private GlueClient awsGlue;
@@ -98,7 +100,7 @@ public class BackfillDataWarehouseBuilderImpl implements BackfillDataWarehouseBu
     public BackfillDataWarehouseBuilderImpl(CloudFormationClientWrapper cloudFormationClientWrapper, VelocityEngine velocityEngine,
                                             Configuration config, LoggerFactory loggerFactory,
                                             StackTagsProvider tagsProvider, ArtifactDownload downloader,
-                                            AmazonS3 s3Client, GlueClient awsGlue, AthenaClient athena) {
+                                            S3Client s3Client, GlueClient awsGlue, AthenaClient athena) {
         this.cloudFormationClientWrapper = cloudFormationClientWrapper;
         this.velocityEngine = velocityEngine;
         this.config = config;
@@ -196,8 +198,9 @@ public class BackfillDataWarehouseBuilderImpl implements BackfillDataWarehouseBu
                     String scriptFile = entry.getName();
                     String s3Key = s3ScriptsPath + scriptFile.replace(scriptPath, "");
                     logger.info("Uploading " + scriptFile + " to " + s3Key);
-                    // Uses a stream with close disabled so that the s3 sdk does not close it for us
-                    s3Client.putObject(bucket, s3Key, ReleasableInputStream.wrap(zipInputStream).disableClose(), null);
+                    // Read the current zip entry into memory so the upload does not close the shared zip stream
+                    byte[] bytes = zipInputStream.readAllBytes();
+                    s3Client.putObject(PutObjectRequest.builder().bucket(bucket).key(s3Key).build(), RequestBody.fromBytes(bytes));
                 }
             }
         } catch (IOException e) {
@@ -209,13 +212,14 @@ public class BackfillDataWarehouseBuilderImpl implements BackfillDataWarehouseBu
     }
 
     private void createGluePartitionForOldData(String prefix, String bucketName, String databaseName) {
-        ListObjectsV2Request listObjectsV2Request = new ListObjectsV2Request().withPrefix(prefix).withBucketName(bucketName).withDelimiter("/");
-        ListObjectsV2Result s3ObjectResult = s3Client.listObjectsV2(listObjectsV2Request);
-        if (s3ObjectResult == null || s3ObjectResult.getCommonPrefixes().size() == 0) {
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder().prefix(prefix).bucket(bucketName).delimiter("/").build();
+        ListObjectsV2Response s3ObjectResult = s3Client.listObjectsV2(listObjectsV2Request);
+        if (s3ObjectResult.commonPrefixes().isEmpty()) {
             getBatchPartitionParametersAndCreateGluePartition(prefix, databaseName, bucketName);
             return;
         }
-        for (String newPath : s3ObjectResult.getCommonPrefixes()) {
+        for (CommonPrefix commonPrefix : s3ObjectResult.commonPrefixes()) {
+            String newPath = commonPrefix.prefix();
             if (checkToIterate(prefix, newPath)) {
                 createGluePartitionForOldData(newPath, bucketName, databaseName);
             }

--- a/src/main/java/org/sagebionetworks/template/repo/beanstalk/ArtifactCopyImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/beanstalk/ArtifactCopyImpl.java
@@ -8,20 +8,25 @@ import org.sagebionetworks.template.LoggerFactory;
 import org.sagebionetworks.template.repo.beanstalk.ssl.ElasticBeanstalkExtentionBuilder;
 import org.sagebionetworks.template.utils.ArtifactDownload;
 
-import com.amazonaws.services.s3.AmazonS3;
 import com.google.inject.Inject;
+
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 public class ArtifactCopyImpl implements ArtifactCopy {
 
-	private AmazonS3 s3Client;
+	private S3Client s3Client;
 	private Configuration configuration;
 	private ArtifactDownload downloader;
 	private ElasticBeanstalkExtentionBuilder ebBuilder;
-	
+
 	private Logger logger;
 
 	@Inject
-	public ArtifactCopyImpl(AmazonS3 s3Client, Configuration propertyProvider,
+	public ArtifactCopyImpl(S3Client s3Client, Configuration propertyProvider,
 			ArtifactDownload downloader, LoggerFactory loggerFactory, ElasticBeanstalkExtentionBuilder ebBuilder) {
 		super();
 		this.s3Client = s3Client;
@@ -38,7 +43,7 @@ public class ArtifactCopyImpl implements ArtifactCopy {
 		logger.info("Looking for: "+s3Key);
 		SourceBundle bundle = new SourceBundle(bucket, s3Key);
 		// does the file already exist in S3
- 		if (!s3Client.doesObjectExist(bucket, s3Key)) {
+ 		if (!doesObjectExist(bucket, s3Key)) {
 			/*
 			 * The file does not exist in S3 so it will needed to be downloaded from
 			 * Artifactory and then uploaded to S3
@@ -52,7 +57,8 @@ public class ArtifactCopyImpl implements ArtifactCopy {
 				// add the .eb extensions to the given war file.
 				warWithExtentions = ebBuilder.copyWarWithExtensions(download, environment);
 				logger.info("Uploading artifact to S3: "+s3Key);
-				s3Client.putObject(bucket, s3Key, warWithExtentions);
+				s3Client.putObject(PutObjectRequest.builder().bucket(bucket).key(s3Key).build(),
+						RequestBody.fromFile(warWithExtentions));
 			} finally {
 				// cleanup the temp file
 				download.delete();
@@ -62,6 +68,20 @@ public class ArtifactCopyImpl implements ArtifactCopy {
 			}
 		}
 		return bundle;
+	}
+
+	/**
+	 * Does the given object already exist in S3? The v2 SDK has no direct equivalent of the v1
+	 * doesObjectExist(), so a headObject is issued and a missing object is signaled by a
+	 * NoSuchKeyException.
+	 */
+	private boolean doesObjectExist(String bucket, String key) {
+		try {
+			s3Client.headObject(HeadObjectRequest.builder().bucket(bucket).key(key).build());
+			return true;
+		} catch (NoSuchKeyException e) {
+			return false;
+		}
 	}
 
 }

--- a/src/main/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImpl.java
@@ -6,7 +6,6 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_REPOSITORY_DAT
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_SECRET_KEYS_CSV;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 
-import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
@@ -17,15 +16,15 @@ import java.util.StringJoiner;
 
 import org.sagebionetworks.template.config.Configuration;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.google.inject.Inject;
 import org.sagebionetworks.template.config.RepoConfiguration;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.EncryptRequest;
 import software.amazon.awssdk.services.kms.model.EncryptResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
@@ -41,10 +40,10 @@ public class SecretBuilderImpl implements SecretBuilder {
 	Configuration config;
 	SecretsManagerClient secretManager;
 	KmsClient keyManager;
-	AmazonS3 s3Client;
-	
+	S3Client s3Client;
+
 	@Inject
-	public SecretBuilderImpl(RepoConfiguration config, SecretsManagerClient secretManager, KmsClient keyManager, AmazonS3 s3Client) {
+	public SecretBuilderImpl(RepoConfiguration config, SecretsManagerClient secretManager, KmsClient keyManager, S3Client s3Client) {
 		super();
 		this.config = config;
 		this.secretManager = secretManager;
@@ -74,9 +73,8 @@ public class SecretBuilderImpl implements SecretBuilder {
 			String bucket = config.getConfigurationBucket();
 			String key = createSecretS3Key();
 			byte[] bytes = getPropertiesBytes(secrets);
-			ObjectMetadata metadata = new ObjectMetadata();
-			metadata.setContentLength(bytes.length);
-			s3Client.putObject(new PutObjectRequest(bucket, key, new ByteArrayInputStream(bytes), metadata));
+			s3Client.putObject(PutObjectRequest.builder().bucket(bucket).key(key).build(),
+					RequestBody.fromBytes(bytes));
 			return new SourceBundle(bucket, key);
 	}
 	

--- a/src/test/java/org/sagebionetworks/template/CloudFormationClientWrapperImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/CloudFormationClientWrapperImplTest.java
@@ -33,10 +33,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.template.config.Configuration;
 import org.sagebionetworks.template.repo.beanstalk.SourceBundle;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
 import software.amazon.awssdk.services.cloudformation.model.Capability;
 import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
@@ -69,7 +70,7 @@ public class CloudFormationClientWrapperImplTest {
 	@Mock
 	CloudFormationClient mockCloudFormationClient;
 	@Mock
-	AmazonS3 mockS3Client;
+	S3Client mockS3Client;
 	@Mock
 	Configuration mockConfig;
 	@Mock
@@ -320,13 +321,15 @@ public class CloudFormationClientWrapperImplTest {
 		assertTrue(bundle.getKey().startsWith("templates/someStackName"));
 		assertTrue(bundle.getKey().endsWith(".json"));
 		ArgumentCaptor<PutObjectRequest> requestCapture = ArgumentCaptor.forClass(PutObjectRequest.class);
-		verify(mockS3Client).putObject(requestCapture.capture());
+		ArgumentCaptor<RequestBody> bodyCapture = ArgumentCaptor.forClass(RequestBody.class);
+		verify(mockS3Client).putObject(requestCapture.capture(), bodyCapture.capture());
 		PutObjectRequest request = requestCapture.getValue();
 		Assertions.assertNotNull(request);
-		Assertions.assertEquals(bucket, request.getBucketName());
-		Assertions.assertEquals(bundle.getKey(), request.getKey());
-		Assertions.assertNotNull(request.getMetadata());
-		Assertions.assertEquals(4L, request.getMetadata().getContentLength());
+		Assertions.assertEquals(bucket, request.bucket());
+		Assertions.assertEquals(bundle.getKey(), request.key());
+		RequestBody body = bodyCapture.getValue();
+		Assertions.assertNotNull(body);
+		Assertions.assertEquals(4L, body.optionalContentLength().orElse(-1L));
 	}
 
 	@Test
@@ -335,7 +338,7 @@ public class CloudFormationClientWrapperImplTest {
 		SourceBundle bundle = new SourceBundle(bucket, key);
 		// call under test
 		client.deleteTemplate(bundle);
-		verify(mockS3Client).deleteObject(bucket, key);
+		verify(mockS3Client).deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
 	}
 
 	@Test
@@ -344,9 +347,9 @@ public class CloudFormationClientWrapperImplTest {
 		when(mockFunction.apply(anyString())).thenReturn(stackId);
 		// call under test
 		client.executeWithS3Template(inputReqequest, mockFunction);
-		verify(mockS3Client).putObject(any(PutObjectRequest.class));
+		verify(mockS3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 		verify(mockFunction).apply(anyString());
-		verify(mockS3Client).deleteObject(anyString(), anyString());
+		verify(mockS3Client).deleteObject(any(DeleteObjectRequest.class));
 	}
 
 
@@ -366,9 +369,9 @@ public class CloudFormationClientWrapperImplTest {
 		// call under test
 		client.executeWithS3Template(inputReqequest, mockFunction);
 
-		verify(mockS3Client).putObject(any(PutObjectRequest.class));
+		verify(mockS3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 		verify(mockFunction).apply(any(String.class));
-		verify(mockS3Client).deleteObject(any(String.class), any(String.class));
+		verify(mockS3Client).deleteObject(any(DeleteObjectRequest.class));
 		verify(mockLogger).info(any(String.class));
 	}
 

--- a/src/test/java/org/sagebionetworks/template/datawarehouse/DataWarehouseBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/datawarehouse/DataWarehouseBuilderImplTest.java
@@ -1,6 +1,5 @@
 package org.sagebionetworks.template.datawarehouse;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.apache.logging.log4j.Logger;
 import org.apache.velocity.app.VelocityEngine;
 import org.json.JSONObject;
@@ -29,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -36,14 +36,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DATAWAREHOUSE_GLUE_DATABASE_NAME;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_STACK;
 
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.cloudformation.model.Tag;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @ExtendWith(MockitoExtension.class)
 public class DataWarehouseBuilderImplTest {
@@ -69,7 +72,9 @@ public class DataWarehouseBuilderImplTest {
 	@Mock
 	private ArtifactDownload mockDownloader;
 	@Mock
-	private AmazonS3 mockS3Client;
+	private S3Client mockS3Client;
+	@Captor
+	ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor;
 
 	private DataWarehouseBuilderImpl builder;
 
@@ -147,8 +152,12 @@ public class DataWarehouseBuilderImplTest {
 		builder.buildAndDeploy();
 
 		verify(mockDownloader).downloadFile("https://codeload.github.com/Sage-Bionetworks/repo/zip/refs/tags/v1.0.0");
-		verify(mockS3Client).putObject(eq("dev.aws-glue.sagebase.org"), eq("scripts/v1.0.0/testjob.py"), any(), any());
-		verify(mockS3Client).putObject(eq("dev.aws-glue.sagebase.org"), eq("scripts/v1.0.0/utilities/utils.py"), any(), any());
+		verify(mockS3Client, times(2)).putObject(putObjectRequestCaptor.capture(), any(RequestBody.class));
+		List<PutObjectRequest> putRequests = putObjectRequestCaptor.getAllValues();
+		assertEquals(List.of("dev.aws-glue.sagebase.org", "dev.aws-glue.sagebase.org"),
+				putRequests.stream().map(PutObjectRequest::bucket).collect(Collectors.toList()));
+		assertEquals(List.of("scripts/v1.0.0/testjob.py", "scripts/v1.0.0/utilities/utils.py"),
+				putRequests.stream().map(PutObjectRequest::key).collect(Collectors.toList()));
 		verifyNoMoreInteractions(mockS3Client);
 
 		verify(cloudFormationClientWrapper).createOrUpdateStack(requestCaptor.capture());

--- a/src/test/java/org/sagebionetworks/template/repo/beanstalk/ArtifactCopyImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/beanstalk/ArtifactCopyImplTest.java
@@ -17,6 +17,8 @@ import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sagebionetworks.template.LoggerFactory;
@@ -24,21 +26,26 @@ import org.sagebionetworks.template.config.Configuration;
 import org.sagebionetworks.template.repo.beanstalk.ssl.ElasticBeanstalkExtentionBuilder;
 import org.sagebionetworks.template.utils.ArtifactDownload;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 @ExtendWith(MockitoExtension.class)
 public class ArtifactCopyImplTest {
-	
+
 	@Mock
-	AmazonS3 mockS3Client;
+	S3Client mockS3Client;
 	@Mock
 	Configuration mockPropertyProvider;
 	@Mock
 	ArtifactDownload mockDownloader;
 	@Mock
 	File mockFile;
-	@Mock 
+	@Mock
 	File mockCopy;
 	@Mock
 	LoggerFactory mockLoggerFactory;
@@ -46,7 +53,11 @@ public class ArtifactCopyImplTest {
 	Logger mockLogger;
 	@Mock
 	ElasticBeanstalkExtentionBuilder mockEbBuilder;
-	
+	@Captor
+	ArgumentCaptor<PutObjectRequest> putObjectRequestCaptor;
+	@Captor
+	ArgumentCaptor<HeadObjectRequest> headObjectRequestCaptor;
+
 	ArtifactCopyImpl copier;
 	
 	String stack;
@@ -56,82 +67,95 @@ public class ArtifactCopyImplTest {
 	String s3Key;
 	String artifactoryUrl;
 	int beanstalkNumber;
+	File realCopyFile;
 
 	@BeforeEach
-	public void before() {
-		
+	public void before() throws Exception {
+
 		beanstalkNumber = 9;
 		environment = EnvironmentType.REPOSITORY_WORKERS;
 		version = "212.4";
-		
+
 		bucket = "dev-configuration.sage.bionetworks";
 
 		s3Key = environment.createS3Key(version, beanstalkNumber);
 		artifactoryUrl = environment.createArtifactoryUrl(version);
 		when(mockLoggerFactory.getLogger(any())).thenReturn(mockLogger);
 		copier = new ArtifactCopyImpl(mockS3Client, mockPropertyProvider, mockDownloader, mockLoggerFactory, mockEbBuilder);
+		// RequestBody.fromFile() eagerly reads the file's size and mimetype, so the copy must
+		// resolve to a real, existing file path.
+		realCopyFile = File.createTempFile("artifact-copy", ".war");
+		realCopyFile.deleteOnExit();
 	}
-	
+
 	@Test
 	public void testCopyArtifactIfNeededDoesNotExist() {
 		when(mockDownloader.downloadFile(any(String.class))).thenReturn(mockFile);
 		when(mockEbBuilder.copyWarWithExtensions(eq(mockFile), any(EnvironmentType.class))).thenReturn(mockCopy);
+		when(mockCopy.toPath()).thenReturn(realCopyFile.toPath());
 		when(mockPropertyProvider.getConfigurationBucket()).thenReturn(bucket);
 		// setup object does not exist
-		when(mockS3Client.doesObjectExist(any(), any())).thenReturn(false);
-		
+		when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().build());
+
 		// call under test
 		SourceBundle result = copier.copyArtifactIfNeeded(environment, version, beanstalkNumber);
 		assertNotNull(result);
 		assertEquals(bucket, result.getBucket());
 		assertEquals(s3Key, result.getKey());
-		
-		verify(mockS3Client).doesObjectExist(bucket, s3Key);
+
+		verify(mockS3Client).headObject(headObjectRequestCaptor.capture());
+		assertEquals(bucket, headObjectRequestCaptor.getValue().bucket());
+		assertEquals(s3Key, headObjectRequestCaptor.getValue().key());
 		verify(mockDownloader).downloadFile(artifactoryUrl);
 		verify(mockEbBuilder).copyWarWithExtensions(eq(mockFile), any(EnvironmentType.class));
-		verify(mockS3Client).putObject(bucket, s3Key, mockCopy);
+		verify(mockS3Client).putObject(putObjectRequestCaptor.capture(), any(RequestBody.class));
+		assertEquals(bucket, putObjectRequestCaptor.getValue().bucket());
+		assertEquals(s3Key, putObjectRequestCaptor.getValue().key());
 		verify(mockLogger, times(4)).info(any(String.class));
 		// the temp file should get deleted.
 		verify(mockFile).delete();
 		verify(mockCopy).delete();
 	}
-	
+
 	@Test
 	public void testCopyArtifactIfNeededUplodFails() {
 		when(mockDownloader.downloadFile(any(String.class))).thenReturn(mockFile);
 		when(mockEbBuilder.copyWarWithExtensions(eq(mockFile), any(EnvironmentType.class))).thenReturn(mockCopy);
+		when(mockCopy.toPath()).thenReturn(realCopyFile.toPath());
 		when(mockPropertyProvider.getConfigurationBucket()).thenReturn(bucket);
-		
-		AmazonServiceException exception = new AmazonServiceException("something");
-		when(mockS3Client.putObject(any(), any(), any(File.class))).thenThrow(exception);
-		
+
+		S3Exception exception = (S3Exception) S3Exception.builder().message("something").build();
+		when(mockS3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(exception);
+
 		// setup object does not exist
-		when(mockS3Client.doesObjectExist(any(), any())).thenReturn(false);
-		
+		when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenThrow(NoSuchKeyException.builder().build());
+
 		// call under test
-		assertThrows(AmazonServiceException.class, ()->{
+		assertThrows(S3Exception.class, ()->{
 			copier.copyArtifactIfNeeded(environment, version, beanstalkNumber);
 		});
 		// file should be deleted even for a failure.
 		verify(mockFile).delete();
 	}
-	
+
 	@Test
 	public void testCopyArtifactIfNeededExist() {
 		when(mockPropertyProvider.getConfigurationBucket()).thenReturn(bucket);
 		// setup object exists
-		when(mockS3Client.doesObjectExist(any(), any())).thenReturn(true);
-		
+		when(mockS3Client.headObject(any(HeadObjectRequest.class))).thenReturn(HeadObjectResponse.builder().build());
+
 		// call under test
 		SourceBundle result = copier.copyArtifactIfNeeded(environment, version, beanstalkNumber);
 		assertNotNull(result);
 		assertEquals(bucket, result.getBucket());
 		assertEquals(s3Key, result.getKey());
-		
-		verify(mockS3Client).doesObjectExist(bucket, s3Key);
+
+		verify(mockS3Client).headObject(headObjectRequestCaptor.capture());
+		assertEquals(bucket, headObjectRequestCaptor.getValue().bucket());
+		assertEquals(s3Key, headObjectRequestCaptor.getValue().key());
 		verify(mockDownloader, never()).downloadFile(artifactoryUrl);
 		verify(mockEbBuilder, never()).copyWarWithExtensions(eq(mockFile), any(EnvironmentType.class));
-		verify(mockS3Client, never()).putObject(bucket, s3Key, mockFile);
+		verify(mockS3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
 		verify(mockFile, never()).delete();
 		verify(mockLogger, times(1)).info(any(String.class));
 	}

--- a/src/test/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/beanstalk/SecretBuilderImplTest.java
@@ -23,13 +23,13 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.sagebionetworks.template.config.RepoConfiguration;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.EncryptRequest;
 import software.amazon.awssdk.services.kms.model.EncryptResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
@@ -44,14 +44,16 @@ public class SecretBuilderImplTest {
 	@Mock
 	KmsClient mockKeyManager;
 	@Mock
-	AmazonS3 mockS3Client;
-	
+	S3Client mockS3Client;
+
 	@Captor
 	ArgumentCaptor<GetSecretValueRequest> secretRequestCaptor;
 	@Captor
 	ArgumentCaptor<EncryptRequest> encryptRequestCaptor;
 	@Captor
 	ArgumentCaptor<PutObjectRequest> putObjectRequsetCaptor;
+	@Captor
+	ArgumentCaptor<RequestBody> requestBodyCaptor;
 	
 	String stack;
 	String instance;
@@ -158,13 +160,14 @@ public class SecretBuilderImplTest {
 		assertNotNull(bundle);
 		assertEquals(s3Bucket, bundle.getBucket());
 		assertEquals(expectedS3Key, bundle.getKey());
-		verify(mockS3Client).putObject(putObjectRequsetCaptor.capture());
+		verify(mockS3Client).putObject(putObjectRequsetCaptor.capture(), requestBodyCaptor.capture());
 		PutObjectRequest request = putObjectRequsetCaptor.getValue();
 		assertNotNull(request);
-		assertEquals(s3Bucket, request.getBucketName());
-		assertEquals(expectedS3Key, request.getKey());
-		assertNotNull(request.getMetadata());
-		assertEquals(propertyBytes.length, request.getMetadata().getContentLength());
+		assertEquals(s3Bucket, request.bucket());
+		assertEquals(expectedS3Key, request.key());
+		RequestBody requestBody = requestBodyCaptor.getValue();
+		assertNotNull(requestBody);
+		assertEquals(propertyBytes.length, requestBody.optionalContentLength().orElse(-1L).longValue());
 	}
 	
 	@Test


### PR DESCRIPTION
Opus-driven:

P3: Beanstalk uploads
P4: Data warehouse
P5: Cloudformation uploads

- 2026-07-14: Phase 3 completed. Migrated ArtifactCopyImpl (doesObjectExist→headObject+NoSuchKeyException catch; putObject File→RequestBody.fromFile) and SecretBuilderImpl (putObject stream+metadata→RequestBody.fromBytes) to v2 S3Client. Updated ArtifactCopyImplTest (mock headObject/NoSuchKeyException/S3Exception; capture PutObjectRequest) and SecretBuilderImplTest (v2 PutObjectRequest getters; verify RequestBody content length). All 401 tests pass.

- 2026-07-14: Phase 5 completed. Migrated CloudFormationClientWrapperImpl to v2 S3Client. saveTemplateToS3 now uses PutObjectRequest.builder() + RequestBody.fromString(template) (dropped ByteArrayInputStream/ObjectMetadata and the UnsupportedEncodingException try/catch — UTF-8 length is derived by RequestBody). deleteTemplate uses DeleteObjectRequest.builder(). Updated CloudFormationClientWrapperImplTest (mock S3Client; capture PutObjectRequest + RequestBody, assert bucket()/key() and RequestBody.optionalContentLength()==4; deleteObject verified via DeleteObjectRequest). All 401 tests pass.

- 2026-07-14: Phase 4 completed. Migrated DataWarehouseBuilderImpl and BackfillDataWarehouseBuilderImpl to v2 S3Client. Zip-entry uploads now read the current entry via ZipInputStream.readAllBytes() into a byte[] and use RequestBody.fromBytes (dropped com.amazonaws.internal.ReleasableInputStream + disableClose hack; v1 already buffered in memory since putObject was called with null metadata / no content-length). Backfill listing migrated to v2 ListObjectsV2Request builder + response.commonPrefixes() (CommonPrefix.prefix()). Updated DataWarehouseBuilderImplTest to mock S3Client and capture PutObjectRequest (assert bucket()/key() for both uploads). No backfill test exists. All 401 tests pass.

