### PR TITLE
add-docusign-properties

### DIFF
--- a/src/main/java/org/sagebionetworks/template/Constants.java
+++ b/src/main/java/org/sagebionetworks/template/Constants.java
@@ -161,6 +161,10 @@ public class Constants {
 	public static final String SAGEBIO_COGNITO_APP_CLIENT_SECRET = "org.sagebionetworks.oauth2.sagebio.client.secret";
 	public static final String SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT = "org.sagebionetworks.oauth2.sagebio.discoveryDocument";
 
+	// DocuSign base path URLs passed through to the running application
+	public static final String PROPERTY_KEY_DOCUSIGN_API_BASE_PATH = "org.sagebionetworks.docusign.api.base.path";
+	public static final String PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH = "org.sagebionetworks.docusign.oauth.base.path";
+
 	// templates
 	public static final String TEMPLATES_VPC_MAIN_VPC_JSON_VTP = "templates/vpc/main-vpc.json.vtp";
 	public static final String TEMPLATES_VPC_PUBLIC_SUBNETS_JSON_VTP = "templates/vpc/public-subnets-resources.json.vtp";
@@ -277,6 +281,8 @@ public class Constants {
 	public static final String CTXT_ENABLE_ENHANCED_RDS_MONITORING = "EnableRdsEnhancedMonitoring";
 
 	public static final String CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL = "DiscoveryDocumentUrl";
+	public static final String CTXT_KEY_DOCUSIGN_API_BASE_PATH = "docusignApiBasePath";
+	public static final String CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH = "docusignOauthBasePath";
 	public static final String COGNITO_USER_POOL_CF_OUTPUT_NAME = "CognitoUserPoolId";
 	public static final String COGNITO_USER_POOL_CLIENT_CF_OUTPUT_NAME = "CognitoUserPoolClientId";
 

--- a/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
+++ b/src/main/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImpl.java
@@ -9,6 +9,8 @@ import static org.sagebionetworks.template.Constants.CTXT_ENABLE_ENHANCED_RDS_MO
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_CDN_DOMAIN_NAME;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_CDN_PRIVATE_KEY_ID;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL;
+import static org.sagebionetworks.template.Constants.CTXT_KEY_DOCUSIGN_API_BASE_PATH;
+import static org.sagebionetworks.template.Constants.CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH;
 import static org.sagebionetworks.template.Constants.DATABASE_DESCRIPTORS;
 import static org.sagebionetworks.template.Constants.DATA_CDN_DOMAIN_NAME_FMT;
 import static org.sagebionetworks.template.Constants.DB_ENDPOINT_SUFFIX;
@@ -36,6 +38,8 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_NUMB
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_SSL_ARN;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_VERSION;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DOCUSIGN_API_BASE_PATH;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DEPLOYMENT_BEANSTALK_OR_ECS;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_MEMORY;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_TYPE;
@@ -352,6 +356,10 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 		context.put(CTXT_KEY_DATA_CDN_DOMAIN_NAME, String.format(DATA_CDN_DOMAIN_NAME_FMT, stack));
 		context.put(CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL, config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT));
 
+		// DocuSign base paths
+		context.put(CTXT_KEY_DOCUSIGN_API_BASE_PATH, config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH));
+		context.put(CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH, config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH));
+
 		// Subnets for ECS tasks and ALB
 		List<String> vpcSubnets = getPrivateSubnets(config.getProperty(PROPERTY_KEY_VPC_SUBNET_COLOR));
 		context.put("ecsSubnetsList", vpcSubnets);
@@ -427,6 +435,10 @@ public class RepositoryTemplateBuilderImpl implements RepositoryTemplateBuilder 
 		context.put(CTXT_KEY_DATA_CDN_DOMAIN_NAME, String.format(DATA_CDN_DOMAIN_NAME_FMT, stack));
 
 		context.put(CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL, config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT));
+
+		// DocuSign base paths
+		context.put(CTXT_KEY_DOCUSIGN_API_BASE_PATH, config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH));
+		context.put(CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH, config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH));
 
 		return context;
 	}

--- a/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
+++ b/src/main/resources/templates/repo/ecs-fargate-template.json.vpt
@@ -334,6 +334,14 @@
 							{
 								"Name": "org.sagebionetworks.oauth2.sagebio.discoveryDocument",
 								"Value": "${DiscoveryDocumentUrl}"
+							},
+							{
+								"Name": "org.sagebionetworks.docusign.api.base.path",
+								"Value": "${docusignApiBasePath}"
+							},
+							{
+								"Name": "org.sagebionetworks.docusign.oauth.base.path",
+								"Value": "${docusignOauthBasePath}"
 							}
 							#end
 						]

--- a/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
+++ b/src/main/resources/templates/repo/elasticbeanstalk-template.json.vpt
@@ -561,6 +561,16 @@
 						"Namespace": "aws:elasticbeanstalk:application:environment",
 						"OptionName": "org.sagebionetworks.oauth2.sagebio.discoveryDocument",
 						"Value": "${DiscoveryDocumentUrl}"
+					},
+					{
+						"Namespace": "aws:elasticbeanstalk:application:environment",
+						"OptionName": "org.sagebionetworks.docusign.api.base.path",
+						"Value": "${docusignApiBasePath}"
+					},
+					{
+						"Namespace": "aws:elasticbeanstalk:application:environment",
+						"OptionName": "org.sagebionetworks.docusign.oauth.base.path",
+						"Value": "${docusignOauthBasePath}"
 					}
 
 					#end

--- a/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
+++ b/src/test/java/org/sagebionetworks/template/repo/RepositoryTemplateBuilderImplTest.java
@@ -22,6 +22,8 @@ import static org.sagebionetworks.template.Constants.CLOUDWATCH_LOGS_DESCRIPTORS
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_CDN_DOMAIN_NAME;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_CDN_PRIVATE_KEY_ID;
 import static org.sagebionetworks.template.Constants.CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL;
+import static org.sagebionetworks.template.Constants.CTXT_KEY_DOCUSIGN_API_BASE_PATH;
+import static org.sagebionetworks.template.Constants.CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH;
 import static org.sagebionetworks.template.Constants.DATABASE_DESCRIPTORS;
 import static org.sagebionetworks.template.Constants.DB_ENDPOINT_SUFFIX;
 import static org.sagebionetworks.template.Constants.DELETION_POLICY;
@@ -43,6 +45,8 @@ import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_NUMB
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_SSL_ARN;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_BEANSTALK_VERSION;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DOCUSIGN_API_BASE_PATH;
+import static org.sagebionetworks.template.Constants.PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_MEMORY;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_EC2_INSTANCE_TYPE;
 import static org.sagebionetworks.template.Constants.PROPERTY_KEY_ECS_CONTAINER_PORT;
@@ -352,6 +356,8 @@ public class RepositoryTemplateBuilderImplTest {
 				eq(2))).thenReturn(EXPECTED_SUBNETS);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
 
 		// call under test
@@ -557,6 +563,8 @@ public class RepositoryTemplateBuilderImplTest {
 				eq(2))).thenReturn(EXPECTED_SUBNETS);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
 
 		// call under test
@@ -681,6 +689,8 @@ public class RepositoryTemplateBuilderImplTest {
 		configureStack(stack);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
 
 		// call under test
@@ -843,6 +853,8 @@ public class RepositoryTemplateBuilderImplTest {
 		configureStack(stack);
 		when(config.getProperty(PROPERTY_KEY_DATA_CDN_PRIVATE_KEY_ID)).thenReturn("CdnPrivateKeyId");
 		when(config.getProperty(SAGEBIO_COGNITO_APP_DISCOVERY_DOCUMENT)).thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 		when(mockImageBuilderClient.getLatestImageIdForImagePipelineArn(imagePipelineArn)).thenReturn(imageId);
 
 		// call under test
@@ -1359,6 +1371,8 @@ public class RepositoryTemplateBuilderImplTest {
 		when(config.getProperty("org.sagebionetworks.cloudfront.private.key.id")).thenReturn("dataCdnPrivateKeyId");
 		when(config.getProperty("org.sagebionetworks.oauth2.sagebio.discoveryDocument"))
 				.thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 
 		EnvironmentDescriptor environment = new EnvironmentDescriptor().withType(EnvironmentType.REPOSITORY_SERVICES);
 
@@ -1381,6 +1395,8 @@ public class RepositoryTemplateBuilderImplTest {
 		assertEquals("data.dev.sagebase.org", context.get(CTXT_KEY_DATA_CDN_DOMAIN_NAME));
 		assertEquals("dataCdnPrivateKeyId", context.get(CTXT_KEY_DATA_CDN_PRIVATE_KEY_ID));
 		assertEquals("discoveryDocumentUrl", context.get(CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL));
+		assertEquals("docusignApiBasePath", context.get(CTXT_KEY_DOCUSIGN_API_BASE_PATH));
+		assertEquals("docusignOauthBasePath", context.get(CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH));
 	}
 
 	@Test
@@ -1748,6 +1764,8 @@ public class RepositoryTemplateBuilderImplTest {
 		when(config.getProperty("org.sagebionetworks.cloudfront.private.key.id")).thenReturn("dataCdnPrivateKeyId");
 		when(config.getProperty("org.sagebionetworks.oauth2.sagebio.discoveryDocument"))
 				.thenReturn("discoveryDocumentUrl");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_API_BASE_PATH)).thenReturn("docusignApiBasePath");
+		when(config.getProperty(PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH)).thenReturn("docusignOauthBasePath");
 		when(mockLoadBalancerAlarmsConfig.getOrDefault(any(), any())).thenReturn(java.util.Collections.emptyList());
 
 		EcsEnvironmentDescriptor environment = new EcsEnvironmentDescriptor()
@@ -1772,6 +1790,8 @@ public class RepositoryTemplateBuilderImplTest {
 		assertEquals("data.dev.sagebase.org", context.get(CTXT_KEY_DATA_CDN_DOMAIN_NAME));
 		assertEquals("dataCdnPrivateKeyId", context.get(CTXT_KEY_DATA_CDN_PRIVATE_KEY_ID));
 		assertEquals("discoveryDocumentUrl", context.get(CTXT_KEY_DATA_DISCOVERY_DOCUMENT_URL));
+		assertEquals("docusignApiBasePath", context.get(CTXT_KEY_DOCUSIGN_API_BASE_PATH));
+		assertEquals("docusignOauthBasePath", context.get(CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH));
 		assertEquals(EXPECTED_SUBNETS, context.get("ecsSubnetsList"));
 		assertNotNull(context.get("targetGroup"));
 		assertNotNull(context.get(CLOUDWATCH_LOGS_DESCRIPTORS));


### PR DESCRIPTION
The two new properties, `org.sagebionetworks.docusign.api.base.path` and `org.sagebionetworks.docusign.oauth.base.path`, are now forwarded to Synapse.

  Changes:

  1. Constants.java — added property-key constants (PROPERTY_KEY_DOCUSIGN_API_BASE_PATH, PROPERTY_KEY_DOCUSIGN_OAUTH_BASE_PATH) and Velocity context-key constants (CTXT_KEY_DOCUSIGN_API_BASE_PATH → docusignApiBasePath, CTXT_KEY_DOCUSIGN_OAUTH_BASE_PATH → docusignOauthBasePath).
  2. RepositoryTemplateBuilderImpl.java — read each via config.getProperty(...) and context.put(...) in both createEnvironmentContext (Beanstalk) and createEcsEnvironmentContext (ECS Fargate).
  3. elasticbeanstalk-template.json.vpt — two new OptionName/Value entries in the aws:elasticbeanstalk:application:environment block.
  4. ecs-fargate-template.json.vpt — two new Name/Value entries in the container Environment array.
  5. RepositoryTemplateBuilderImplTest.java — added stubs (required by strict Mockito, since getProperty is now called with the new keys in these code paths) and assertions in the Beanstalk and ECS context tests.

 Note: I did not add defaults to repo-defaults.properties. getProperty throws if a key is missing, and since these are always passed in as -D system properties by the RepositoryBuilderMain caller (same as discoveryDocument, which also has no default there), no default is needed. If a deployment ever runs without passing them, the build will fail fast with ConfigurationPropertyNotFound — consistent with the "always set" assumption. Let me know if you'd rather I add empty/default values as a safety net.
